### PR TITLE
Prevent a residue from being edged with itself

### DIFF
--- a/deeprankcore/tools/graph.py
+++ b/deeprankcore/tools/graph.py
@@ -75,22 +75,24 @@ def build_residue_graph( # pylint: disable=too-many-locals
             residue1 = atom1.residue
             residue2 = atom2.residue
 
-            contact = ResidueContact(residue1, residue2)
+            if residue1 != residue2:
 
-            node1 = Node(residue1)
-            node2 = Node(residue2)
+                contact = ResidueContact(residue1, residue2)
 
-            node1.features[FEATURENAME_POSITION] = numpy.mean(
-                [atom.position for atom in residue1.atoms], axis=0
-            )
-            node2.features[FEATURENAME_POSITION] = numpy.mean(
-                [atom.position for atom in residue2.atoms], axis=0
-            )
+                node1 = Node(residue1)
+                node2 = Node(residue2)
 
-            # The same residue will be added  multiple times as a node,
-            # but the Graph class fixes this.
-            graph.add_node(node1)
-            graph.add_node(node2)
-            graph.add_edge(Edge(contact))
+                node1.features[FEATURENAME_POSITION] = numpy.mean(
+                    [atom.position for atom in residue1.atoms], axis=0
+                )
+                node2.features[FEATURENAME_POSITION] = numpy.mean(
+                    [atom.position for atom in residue2.atoms], axis=0
+                )
+
+                # The same residue will be added  multiple times as a node,
+                # but the Graph class fixes this.
+                graph.add_node(node1)
+                graph.add_node(node2)
+                graph.add_edge(Edge(contact))
 
     return graph

--- a/tests/data/pdb/3MRC/3MRC.pdb
+++ b/tests/data/pdb/3MRC/3MRC.pdb
@@ -1,0 +1,2951 @@
+HEADER    IMMUNE SYSTEM                           29-APR-10   3MRC              
+TITLE     CRYSTAL STRUCTURE OF MHC CLASS I HLA-A2 MOLECULE COMPLEXED WITH HCMV  
+TITLE    2 PP65-495-503 NONAPEPTIDE V6C VARIANT                                 
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: HLA CLASS I HISTOCOMPATIBILITY ANTIGEN, A-2 ALPHA CHAIN;   
+COMPND   3 CHAIN: A;                                                            
+COMPND   4 FRAGMENT: HLA-A*0201 ALPHA CHAIN, UNP RESIUDE 25-300;                
+COMPND   5 SYNONYM: MHC CLASS I ANTIGEN A*2;                                    
+COMPND   6 ENGINEERED: YES;                                                     
+COMPND   7 MUTATION: YES;                                                       
+COMPND   8 MOL_ID: 2;                                                           
+COMPND   9 MOLECULE: BETA-2-MICROGLOBULIN;                                      
+COMPND  10 CHAIN: B;                                                            
+COMPND  11 SYNONYM: BETA-2-MICROGLOBULIN FORM PI 5.3;                           
+COMPND  12 ENGINEERED: YES;                                                     
+COMPND  13 MOL_ID: 3;                                                           
+COMPND  14 MOLECULE: 9-MERIC PEPTIDE FROM TEGUMENT PROTEIN PP65;                
+COMPND  15 CHAIN: P;                                                            
+COMPND  16 FRAGMENT: UNP RESIDUES 495-503;                                      
+COMPND  17 ENGINEERED: YES;                                                     
+COMPND  18 MUTATION: YES                                                        
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: HOMO SAPIENS;                                   
+SOURCE   3 ORGANISM_COMMON: HUMAN;                                              
+SOURCE   4 ORGANISM_TAXID: 9606;                                                
+SOURCE   5 GENE: HLA, HLA-A, HLAA;                                              
+SOURCE   6 EXPRESSION_SYSTEM: ESCHERICHIA COLI;                                 
+SOURCE   7 EXPRESSION_SYSTEM_TAXID: 562;                                        
+SOURCE   8 EXPRESSION_SYSTEM_STRAIN: X90F LAQQ1;                                
+SOURCE   9 EXPRESSION_SYSTEM_VECTOR_TYPE: PLASMID;                              
+SOURCE  10 EXPRESSION_SYSTEM_PLASMID: PHN1;                                     
+SOURCE  11 MOL_ID: 2;                                                           
+SOURCE  12 ORGANISM_SCIENTIFIC: HOMO SAPIENS;                                   
+SOURCE  13 ORGANISM_COMMON: HUMAN;                                              
+SOURCE  14 ORGANISM_TAXID: 9606;                                                
+SOURCE  15 GENE: B2M, BETA-2 MICROGLUBULIN, CDABP0092, HDCMA22P;                
+SOURCE  16 EXPRESSION_SYSTEM: ESCHERICHIA COLI;                                 
+SOURCE  17 EXPRESSION_SYSTEM_TAXID: 562;                                        
+SOURCE  18 EXPRESSION_SYSTEM_STRAIN: X90F LAQQ1;                                
+SOURCE  19 EXPRESSION_SYSTEM_VECTOR_TYPE: PLASMID;                              
+SOURCE  20 EXPRESSION_SYSTEM_PLASMID: PHN1;                                     
+SOURCE  21 MOL_ID: 3;                                                           
+SOURCE  22 SYNTHETIC: YES;                                                      
+SOURCE  23 ORGANISM_SCIENTIFIC: HUMAN CYTOMEGALOVIRUS HCMV;                     
+SOURCE  24 ORGANISM_COMMON: HHV-5;                                              
+SOURCE  25 ORGANISM_TAXID: 10359;                                               
+SOURCE  26 OTHER_DETAILS: VARIANT OF A SEQUENCE IN HUMAN CYTOMEGALOVIRUS PP65   
+SOURCE  27 PROTEIN                                                              
+KEYWDS    MHC CLASS I, HLA, IMMUNE SYSTEM, IMMUNE RESPONSE, NONAPEPTIDE, VIRAL  
+KEYWDS   2 PEPTIDE, CYTOMEGALOVIRUS, PP65 PROTEIN                               
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    S.GRAS,J.-B.REISER,A.CHOUQUET,E.DEBEAUPUIS,K.ECHASSERIEAU,X.SAULQUIN, 
+AUTHOR   2 M.BONNEVILLE,D.HOUSSET                                               
+REVDAT   1   25-MAY-11 3MRC    0                                                
+JRNL        AUTH   S.GRAS,J.-B.REISER,A.CHOUQUET,E.DEBEAUPUIS,K.ECHASSERIEAU,   
+JRNL        AUTH 2 X.SAULQUIN,M.BONNEVILLE,D.HOUSSET                            
+JRNL        TITL   CRYSTAL STRUCTURE OF MHC CLASS I HLA-A2 MOLECULE COMPLEXED   
+JRNL        TITL 2 WITH HCMV PP65-495-503 NONAPEPTIDE V6C VARIANT               
+JRNL        REF    TO BE PUBLISHED                                              
+JRNL        REFN                                                                
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    1.80 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : REFMAC 5.5.0044                                      
+REMARK   3   AUTHORS     : MURSHUDOV,VAGIN,DODSON                               
+REMARK   3                                                                      
+REMARK   3    REFINEMENT TARGET : MAXIMUM LIKELIHOOD                            
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 1.80                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 15.00                          
+REMARK   3   DATA CUTOFF            (SIGMA(F)) : 0.000                          
+REMARK   3   COMPLETENESS FOR RANGE        (%) : 98.3                           
+REMARK   3   NUMBER OF REFLECTIONS             : 37412                          
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT.                                     
+REMARK   3   CROSS-VALIDATION METHOD          : THROUGHOUT                      
+REMARK   3   FREE R VALUE TEST SET SELECTION  : RANDOM                          
+REMARK   3   R VALUE     (WORKING + TEST SET) : 0.179                           
+REMARK   3   R VALUE            (WORKING SET) : 0.178                           
+REMARK   3   FREE R VALUE                     : 0.223                           
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : 9.900                           
+REMARK   3   FREE R VALUE TEST SET COUNT      : 3721                            
+REMARK   3                                                                      
+REMARK   3  FIT IN THE HIGHEST RESOLUTION BIN.                                  
+REMARK   3   TOTAL NUMBER OF BINS USED           : 20                           
+REMARK   3   BIN RESOLUTION RANGE HIGH       (A) : 1.80                         
+REMARK   3   BIN RESOLUTION RANGE LOW        (A) : 1.85                         
+REMARK   3   REFLECTION IN BIN     (WORKING SET) : 2369                         
+REMARK   3   BIN COMPLETENESS (WORKING+TEST) (%) : 95.30                        
+REMARK   3   BIN R VALUE           (WORKING SET) : 0.2470                       
+REMARK   3   BIN FREE R VALUE SET COUNT          : 267                          
+REMARK   3   BIN FREE R VALUE                    : 0.2950                       
+REMARK   3                                                                      
+REMARK   3  NUMBER OF NON-HYDROGEN ATOMS USED IN REFINEMENT.                    
+REMARK   3   PROTEIN ATOMS            : 3140                                    
+REMARK   3   NUCLEIC ACID ATOMS       : 0                                       
+REMARK   3   HETEROGEN ATOMS          : 0                                       
+REMARK   3   SOLVENT ATOMS            : 201                                     
+REMARK   3                                                                      
+REMARK   3  B VALUES.                                                           
+REMARK   3   FROM WILSON PLOT           (A**2) : 24.61                          
+REMARK   3   MEAN B VALUE      (OVERALL, A**2) : 20.09                          
+REMARK   3   OVERALL ANISOTROPIC B VALUE.                                       
+REMARK   3    B11 (A**2) : -0.10000                                             
+REMARK   3    B22 (A**2) : -0.82000                                             
+REMARK   3    B33 (A**2) : 0.61000                                              
+REMARK   3    B12 (A**2) : 0.00000                                              
+REMARK   3    B13 (A**2) : -0.42000                                             
+REMARK   3    B23 (A**2) : 0.00000                                              
+REMARK   3                                                                      
+REMARK   3  ESTIMATED OVERALL COORDINATE ERROR.                                 
+REMARK   3   ESU BASED ON R VALUE                            (A): NULL          
+REMARK   3   ESU BASED ON FREE R VALUE                       (A): 0.134         
+REMARK   3   ESU BASED ON MAXIMUM LIKELIHOOD                 (A): 0.071         
+REMARK   3   ESU FOR B VALUES BASED ON MAXIMUM LIKELIHOOD (A**2): 2.294         
+REMARK   3                                                                      
+REMARK   3 CORRELATION COEFFICIENTS.                                            
+REMARK   3   CORRELATION COEFFICIENT FO-FC      : 0.953                         
+REMARK   3   CORRELATION COEFFICIENT FO-FC FREE : 0.927                         
+REMARK   3                                                                      
+REMARK   3  RMS DEVIATIONS FROM IDEAL VALUES        COUNT    RMS    WEIGHT      
+REMARK   3   BOND LENGTHS REFINED ATOMS        (A):  3375 ; 0.011 ; 0.021       
+REMARK   3   BOND LENGTHS OTHERS               (A):  NULL ;  NULL ;  NULL       
+REMARK   3   BOND ANGLES REFINED ATOMS   (DEGREES):  4618 ; 1.250 ; 1.925       
+REMARK   3   BOND ANGLES OTHERS          (DEGREES):  NULL ;  NULL ;  NULL       
+REMARK   3   TORSION ANGLES, PERIOD 1    (DEGREES):   425 ; 5.681 ; 5.000       
+REMARK   3   TORSION ANGLES, PERIOD 2    (DEGREES):   181 ;31.104 ;23.149       
+REMARK   3   TORSION ANGLES, PERIOD 3    (DEGREES):   566 ;14.275 ;15.000       
+REMARK   3   TORSION ANGLES, PERIOD 4    (DEGREES):    30 ;16.783 ;15.000       
+REMARK   3   CHIRAL-CENTER RESTRAINTS       (A**3):   478 ; 0.093 ; 0.200       
+REMARK   3   GENERAL PLANES REFINED ATOMS      (A):  2677 ; 0.006 ; 0.021       
+REMARK   3   GENERAL PLANES OTHERS             (A):  NULL ;  NULL ;  NULL       
+REMARK   3   NON-BONDED CONTACTS REFINED ATOMS (A):  NULL ;  NULL ;  NULL       
+REMARK   3   NON-BONDED CONTACTS OTHERS        (A):  NULL ;  NULL ;  NULL       
+REMARK   3   NON-BONDED TORSION REFINED ATOMS  (A):  NULL ;  NULL ;  NULL       
+REMARK   3   NON-BONDED TORSION OTHERS         (A):  NULL ;  NULL ;  NULL       
+REMARK   3   H-BOND (X...Y) REFINED ATOMS      (A):  NULL ;  NULL ;  NULL       
+REMARK   3   H-BOND (X...Y) OTHERS             (A):  NULL ;  NULL ;  NULL       
+REMARK   3   POTENTIAL METAL-ION REFINED ATOMS (A):  NULL ;  NULL ;  NULL       
+REMARK   3   POTENTIAL METAL-ION OTHERS        (A):  NULL ;  NULL ;  NULL       
+REMARK   3   SYMMETRY VDW REFINED ATOMS        (A):  NULL ;  NULL ;  NULL       
+REMARK   3   SYMMETRY VDW OTHERS               (A):  NULL ;  NULL ;  NULL       
+REMARK   3   SYMMETRY H-BOND REFINED ATOMS     (A):  NULL ;  NULL ;  NULL       
+REMARK   3   SYMMETRY H-BOND OTHERS            (A):  NULL ;  NULL ;  NULL       
+REMARK   3   SYMMETRY METAL-ION REFINED ATOMS  (A):  NULL ;  NULL ;  NULL       
+REMARK   3   SYMMETRY METAL-ION OTHERS         (A):  NULL ;  NULL ;  NULL       
+REMARK   3                                                                      
+REMARK   3  ISOTROPIC THERMAL FACTOR RESTRAINTS.     COUNT   RMS    WEIGHT      
+REMARK   3   MAIN-CHAIN BOND REFINED ATOMS  (A**2):  1978 ; 1.141 ; 2.000       
+REMARK   3   MAIN-CHAIN BOND OTHER ATOMS    (A**2):  NULL ;  NULL ;  NULL       
+REMARK   3   MAIN-CHAIN ANGLE REFINED ATOMS (A**2):  3225 ; 2.064 ; 3.000       
+REMARK   3   SIDE-CHAIN BOND REFINED ATOMS  (A**2):  1397 ; 2.174 ; 3.000       
+REMARK   3   SIDE-CHAIN ANGLE REFINED ATOMS (A**2):  1370 ; 3.421 ; 4.000       
+REMARK   3                                                                      
+REMARK   3 ANISOTROPIC THERMAL FACTOR RESTRAINTS.    COUNT   RMS   WEIGHT       
+REMARK   3   RIGID-BOND RESTRAINTS          (A**2):  NULL ;  NULL ;  NULL       
+REMARK   3   SPHERICITY; FREE ATOMS         (A**2):  NULL ;  NULL ;  NULL       
+REMARK   3   SPHERICITY; BONDED ATOMS       (A**2):  NULL ;  NULL ;  NULL       
+REMARK   3                                                                      
+REMARK   3  NCS RESTRAINTS STATISTICS                                           
+REMARK   3   NUMBER OF DIFFERENT NCS GROUPS : NULL                              
+REMARK   3                                                                      
+REMARK   3  TLS DETAILS                                                         
+REMARK   3   NUMBER OF TLS GROUPS  : NULL                                       
+REMARK   3                                                                      
+REMARK   3  BULK SOLVENT MODELLING.                                             
+REMARK   3   METHOD USED : BABINET MODEL WITH MASK                              
+REMARK   3   PARAMETERS FOR MASK CALCULATION                                    
+REMARK   3   VDW PROBE RADIUS   : 1.40                                          
+REMARK   3   ION PROBE RADIUS   : 0.80                                          
+REMARK   3   SHRINKAGE RADIUS   : 0.80                                          
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: U VALUES: REFINED INDIVIDUALLY; 10 TO     
+REMARK   3  20 REFINEMENT CYCLES WITH ALL OBSERVED REFLECTIONS WERE PERFORMED   
+REMARK   3  AT THE END OF THE REFINEMENT PROCEDURE, IN ORDER TO OBTAIN THE      
+REMARK   3  MOST ACCURATE MODEL. RWORK AND RFREE VALUES CORRESPONDS TO THE      
+REMARK   3  COORDINATES JUST BEFORE THESE VERY LAST CYCLES.                     
+REMARK   4                                                                      
+REMARK   4 3MRC COMPLIES WITH FORMAT V. 3.20, 01-DEC-08                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY PDBJ ON 12-MAY-10.                  
+REMARK 100 THE RCSB ID CODE IS RCSB058902.                                      
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : 29-SEP-06                          
+REMARK 200  TEMPERATURE           (KELVIN) : 100                                
+REMARK 200  PH                             : 6.5                                
+REMARK 200  NUMBER OF CRYSTALS USED        : 1                                  
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : Y                                  
+REMARK 200  RADIATION SOURCE               : ESRF                               
+REMARK 200  BEAMLINE                       : ID14-2                             
+REMARK 200  X-RAY GENERATOR MODEL          : NULL                               
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : M                                  
+REMARK 200  WAVELENGTH OR RANGE        (A) : 0.93300                            
+REMARK 200  MONOCHROMATOR                  : NULL                               
+REMARK 200  OPTICS                         : NULL                               
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : CCD                                
+REMARK 200  DETECTOR MANUFACTURER          : ADSC QUANTUM 4                     
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : XDS                                
+REMARK 200  DATA SCALING SOFTWARE          : XSCALE                             
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : 38039                              
+REMARK 200  RESOLUTION RANGE HIGH      (A) : 1.800                              
+REMARK 200  RESOLUTION RANGE LOW       (A) : 20.000                             
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : -3.000                             
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : 99.6                               
+REMARK 200  DATA REDUNDANCY                : 3.720                              
+REMARK 200  R MERGE                    (I) : 0.06600                            
+REMARK 200  R SYM                      (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : 14.3900                            
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : 1.80                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : 1.90                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : 99.7                               
+REMARK 200  DATA REDUNDANCY IN SHELL       : NULL                               
+REMARK 200  R MERGE FOR SHELL          (I) : 0.38600                            
+REMARK 200  R SYM FOR SHELL            (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : 3.500                              
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: SINGLE WAVELENGTH                              
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: MOLECULAR REPLACEMENT        
+REMARK 200 SOFTWARE USED: AMORE                                                 
+REMARK 200 STARTING MODEL: PDB ENTRY 3GSO                                       
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 47.21                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 2.33                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: 12% PEG 6000, 0.1M NACITRATE, 0.15M      
+REMARK 280  NACL, 3.45MG/ML PROTEIN CONC., PH 6.5, VAPOR DIFFUSION, HANGING     
+REMARK 280  DROP, TEMPERATURE 293K                                              
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: P 1 21 1                         
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -X,Y+1/2,-Z                                             
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   2  0.000000  1.000000  0.000000       39.80700            
+REMARK 290   SMTRY3   2  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1                                                       
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: TRIMERIC                          
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: TRIMERIC                   
+REMARK 350 SOFTWARE USED: PISA                                                  
+REMARK 350 TOTAL BURIED SURFACE AREA: 4320 ANGSTROM**2                          
+REMARK 350 SURFACE AREA OF THE COMPLEX: 18760 ANGSTROM**2                       
+REMARK 350 CHANGE IN SOLVENT FREE ENERGY: -18.0 KCAL/MOL                        
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A, B, P                               
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 410                                                                     
+REMARK 410 IMGT/3Dstructure-DB annotations                                     
+REMARK 410 (http://www.imgt.org)                                              
+REMARK 410      
+REMARK 410 ligand(s)
+REMARK 410 9-meric peptide from Tegument protein pp65 (Q6SW59), V6>C         
+REMARK 410 IMGT receptor type
+REMARK 410 
+REMARK 410 IMGT receptor description
+REMARK 410 Peptide                                                           
+REMARK 410 Species
+REMARK 410 Homo sapiens (human)                                              
+REMARK 410 Chain ID
+REMARK 410 3mrc_P                                                            
+REMARK 410
+REMARK 410 IMGT protein name
+REMARK 410 MH1 HLA-A*0201, A245>V                                            
+REMARK 410 IMGT receptor type
+REMARK 410 MH
+REMARK 410 IMGT receptor description
+REMARK 410 MH1-ALPHA_B2M                                                     
+REMARK 410 Species
+REMARK 410 Homo sapiens (human)                                              
+REMARK 410 Chain ID
+REMARK 410 3mrc_A,3mrc_B                                                     
+REMARK 410
+REMARK 410
+REMARK 410 Chain ID                3mrc_A (3MRCA)
+REMARK 410 IMGT chain description  I-ALPHA
+REMARK 410 Chain amino acid sequence
+REMARK 410 [                                  G-ALPHA1 (1-90) [D1]           
+REMARK 410 GSHSMRYFFTSVSRPGRGEPRFIAVGYVDDTQFVRFDSDAASQRMEPRAPWIEQEGPEYWDGETRK
+REMARK 410                        ][                                  G-ALPHA
+REMARK 410 VKAHSQTHRVDLGTLRGYYNQSEAGSHTVQRMYGCDVGSDWRFLRGYHQYAYDGKDYIALKEDLRS
+REMARK 410 2 (91-182) [D2]                                  ][               
+REMARK 410 WTAADMAAQTTKHKWEAAHVAEQLRAYLEGTCVEWLRRYLENGKETLQRTDAPKTHMTHHAVSDHE
+REMARK 410                    C-LIKE (183-274) [D3]                          
+REMARK 410 ATLRCWALSFYPAEITLTWQRDGEDQTQDTELVETRPAGDGTFQKWVAVVVPSGQEQRYTCHVQHE
+REMARK 410          ]                                                        
+REMARK 410 GLPKPLTLRWEP                                                      
+REMARK 410 G-DOMAIN      IMGT domain description  G-ALPHA1
+REMARK 410 G-DOMAIN      IMGT gene and allele     Homo sapiens HLA-A*0201    
+REMARK 410 G-DOMAIN      IMGT gene and allele     (100%)                     
+REMARK 410 G-DOMAIN      ..........GSHSMRY.FFTSVSRPGRGEPRFIAVGYVDDTQFVRFDSDAA
+REMARK 410 G-DOMAIN      SQRMEPRA.......PWIEQEGPEYWDGETRKVKAHSQTHRVDLGTLRGYYN
+REMARK 410 G-DOMAIN      QSEA
+REMARK 410 G-DOMAIN      IMGT domain description  G-ALPHA2
+REMARK 410 G-DOMAIN      IMGT gene and allele     Homo sapiens HLA-A*0201    
+REMARK 410 G-DOMAIN      IMGT gene and allele     (100%)                     
+REMARK 410 G-DOMAIN      ..........GSHTVQRMYGCDVGSDWRFLRGYHQYAYDGKDYIALKED..L
+REMARK 410 G-DOMAIN      RSWTAAD.......MAAQTTKHKWEAA.HVAEQLRAYLEGTCVEWLRRYLEN
+REMARK 410 G-DOMAIN      GKETLQRT
+REMARK 410 C-LIKE-DOMAIN IMGT domain description  C-LIKE
+REMARK 410 C-LIKE-DOMAIN IMGT gene and allele     Homo sapiens HLA-A*0201    
+REMARK 410 C-LIKE-DOMAIN IMGT gene and allele     (98.9%)                    
+REMARK 410 C-LIKE-DOMAIN Sheet composition        [A B D E] [C F G]
+REMARK 410 C-LIKE-DOMAIN .......DAPKTHMTHHAVSD......HEATLRCWALSFYP..AEITLTWQR
+REMARK 410 C-LIKE-DOMAIN DGEDQTQ..DTELVETRPAGD......GTFQKWVAVVVPSG.....QEQRYT
+REMARK 410 C-LIKE-DOMAIN CHVQHEG..LPKPLTLRW
+REMARK 410
+REMARK 410 Chain ID                3mrc_B (3MRCB)
+REMARK 410 IMGT chain description  B2M
+REMARK 410 Chain amino acid sequence
+REMARK 410  [                                       C-LIKE (2-100) [D1]      
+REMARK 410 MIQRTPKIQVYSRHPAENGKSNFLNCYVSGFHPSDIEVDLLKNGERIEKVEHSDLSFSKDWSFYLL
+REMARK 410                                  ]                                
+REMARK 410 YYTEFTPTEKDEYACRVNHVTLSQPKIVKWDRDM                                
+REMARK 410 C-LIKE-DOMAIN IMGT domain description  C-LIKE
+REMARK 410 C-LIKE-DOMAIN IMGT gene and allele     Homo sapiens B2M*01        
+REMARK 410 C-LIKE-DOMAIN IMGT gene and allele     (100%), Homo sapiens       
+REMARK 410 C-LIKE-DOMAIN IMGT gene and allele     B2M*02 (100%)              
+REMARK 410 C-LIKE-DOMAIN Sheet composition        [A B D E] [C F G]
+REMARK 410 C-LIKE-DOMAIN .....IQRTPKIQVYSRHPAEN....GKSNFLNCYVSGFHP..SDIEVDLLK
+REMARK 410 C-LIKE-DOMAIN NGERIE...KVEHSDLSFSKD......WSFYLLYYTEFTPTE.....KDEYA
+REMARK 410 C-LIKE-DOMAIN CRVNHVT..LSQPKIVKWDRDM
+REMARK 465                                                                      
+REMARK 465 MISSING RESIDUES                                                     
+REMARK 465 THE FOLLOWING RESIDUES WERE NOT LOCATED IN THE                       
+REMARK 465 EXPERIMENT. (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN               
+REMARK 465 IDENTIFIER; SSSEQ=SEQUENCE NUMBER; I=INSERTION CODE.)                
+REMARK 465                                                                      
+REMARK 465   M RES C SSSEQI                                                     
+REMARK 465     GLU A   275                                                      
+REMARK 465     PRO A   276                                                      
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: CLOSE CONTACTS IN SAME ASYMMETRIC UNIT                     
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING ATOMS ARE IN CLOSE CONTACT.                            
+REMARK 500                                                                      
+REMARK 500  ATM1  RES C  SSEQI   ATM2  RES C  SSEQI           DISTANCE          
+REMARK 500   O    HOH A   356     O    HOH A   396              2.14            
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    ASP A  29     -123.21     49.10                                   
+REMARK 500    TYR A 123      -65.32   -120.68                                   
+REMARK 500    SER A 195     -175.37   -170.80                                   
+REMARK 500    LYS B  48       52.97    -93.01                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 900                                                                      
+REMARK 900 RELATED ENTRIES                                                      
+REMARK 900 RELATED ID: 3MR9   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/NLV(M5A) COMPLEX                                              
+REMARK 900 RELATED ID: 3MRB   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/NLV(A7H) COMPLEX                                              
+REMARK 900 RELATED ID: 3MRD   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/NLV(V6G) COMPLEX                                              
+REMARK 900 RELATED ID: 3MRE   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/GLC COMPLEX                                                   
+REMARK 900 RELATED ID: 3MRF   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/GLC(T4P) COMPLEX                                              
+REMARK 900 RELATED ID: 3MRG   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/CIN COMPLEX                                                   
+REMARK 900 RELATED ID: 3MRH   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/CIN(N3S) COMPLEX                                              
+REMARK 900 RELATED ID: 3MRI   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/CIN(G4M-V5W) COMPLEX                                          
+REMARK 900 RELATED ID: 3MRJ   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/CIN(V5M) COMPLEX                                              
+REMARK 900 RELATED ID: 3MRK   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/PLF COMPLEX                                                   
+REMARK 900 RELATED ID: 3MRL   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/CIN(C6V) COMPLEX                                              
+REMARK 900 RELATED ID: 3MRM   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/KLV COMPLEX                                                   
+REMARK 900 RELATED ID: 3MRN   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/LLF COMPLEX                                                   
+REMARK 900 RELATED ID: 3MRO   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/ELA(I5W) COMPLEX                                              
+REMARK 900 RELATED ID: 3MRP   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/ELA(I5L-L8N) COMPLEX                                          
+REMARK 900 RELATED ID: 3MRQ   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/ELA(I5L-L8N) COMPLEX                                          
+REMARK 900 RELATED ID: 3MRR   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/LLA COMPLEX                                                   
+REMARK 900 RELATED ID: 3GSN   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/NLV/RA14 TCR COMPLEX                                          
+REMARK 900 RELATED ID: 3GSO   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/NLV COMPLEX                                                   
+REMARK 900 RELATED ID: 3GSQ   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/NLV(M5S) COMPLEX                                              
+REMARK 900 RELATED ID: 3GSR   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/NLV(M5V) COMPLEX                                              
+REMARK 900 RELATED ID: 3GSU   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/NLV(M5T) COMPLEX                                              
+REMARK 900 RELATED ID: 3GSV   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/NLV(M5Q) COMPLEX                                              
+REMARK 900 RELATED ID: 3GSW   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/NLV(T8A) COMPLEX                                              
+REMARK 900 RELATED ID: 3GSX   RELATED DB: PDB                                   
+REMARK 900 HLA-A2/NLV(T8V) COMPLEX                                              
+DBREF  3MRC A    1   276  UNP    P01892   1A02_HUMAN      25    300             
+DBREF  3MRC B    1    99  UNP    P61769   B2MG_HUMAN      21    119             
+DBREF  3MRC P    1     9  UNP    Q6SW59   Q6SW59_HCMV    495    503             
+SEQADV 3MRC VAL A 2087  UNP  P01892    ALA   269 ENGINEERED MUTATION            
+SEQADV 3MRC MET B    1  UNP  P61769              EXPRESSION TAG                 
+SEQADV 3MRC CYS P    6  UNP  Q6SW59    VAL   500 ENGINEERED MUTATION            
+SEQRES   1 A  276  GLY SER HIS SER MET ARG TYR PHE PHE THR SER VAL SER          
+SEQRES   2 A  276  ARG PRO GLY ARG GLY GLU PRO ARG PHE ILE ALA VAL GLY          
+SEQRES   3 A  276  TYR VAL ASP ASP THR GLN PHE VAL ARG PHE ASP SER ASP          
+SEQRES   4 A  276  ALA ALA SER GLN ARG MET GLU PRO ARG ALA PRO TRP ILE          
+SEQRES   5 A  276  GLU GLN GLU GLY PRO GLU TYR TRP ASP GLY GLU THR ARG          
+SEQRES   6 A  276  LYS VAL LYS ALA HIS SER GLN THR HIS ARG VAL ASP LEU          
+SEQRES   7 A  276  GLY THR LEU ARG GLY TYR TYR ASN GLN SER GLU ALA GLY          
+SEQRES   8 A  276  SER HIS THR VAL GLN ARG MET TYR GLY CYS ASP VAL GLY          
+SEQRES   9 A  276  SER ASP TRP ARG PHE LEU ARG GLY TYR HIS GLN TYR ALA          
+SEQRES  10 A  276  TYR ASP GLY LYS ASP TYR ILE ALA LEU LYS GLU ASP LEU          
+SEQRES  11 A  276  ARG SER TRP THR ALA ALA ASP MET ALA ALA GLN THR THR          
+SEQRES  12 A  276  LYS HIS LYS TRP GLU ALA ALA HIS VAL ALA GLU GLN LEU          
+SEQRES  13 A  276  ARG ALA TYR LEU GLU GLY THR CYS VAL GLU TRP LEU ARG          
+SEQRES  14 A  276  ARG TYR LEU GLU ASN GLY LYS GLU THR LEU GLN ARG THR          
+SEQRES  15 A  276  ASP ALA PRO LYS THR HIS MET THR HIS HIS ALA VAL SER          
+SEQRES  16 A  276  ASP HIS GLU ALA THR LEU ARG CYS TRP ALA LEU SER PHE          
+SEQRES  17 A  276  TYR PRO ALA GLU ILE THR LEU THR TRP GLN ARG ASP GLY          
+SEQRES  18 A  276  GLU ASP GLN THR GLN ASP THR GLU LEU VAL GLU THR ARG          
+SEQRES  19 A  276  PRO ALA GLY ASP GLY THR PHE GLN LYS TRP VAL ALA VAL          
+SEQRES  20 A  276  VAL VAL PRO SER GLY GLN GLU GLN ARG TYR THR CYS HIS          
+SEQRES  21 A  276  VAL GLN HIS GLU GLY LEU PRO LYS PRO LEU THR LEU ARG          
+SEQRES  22 A  276  TRP GLU PRO                                                  
+SEQRES   1 B  100  MET ILE GLN ARG THR PRO LYS ILE GLN VAL TYR SER ARG          
+SEQRES   2 B  100  HIS PRO ALA GLU ASN GLY LYS SER ASN PHE LEU ASN CYS          
+SEQRES   3 B  100  TYR VAL SER GLY PHE HIS PRO SER ASP ILE GLU VAL ASP          
+SEQRES   4 B  100  LEU LEU LYS ASN GLY GLU ARG ILE GLU LYS VAL GLU HIS          
+SEQRES   5 B  100  SER ASP LEU SER PHE SER LYS ASP TRP SER PHE TYR LEU          
+SEQRES   6 B  100  LEU TYR TYR THR GLU PHE THR PRO THR GLU LYS ASP GLU          
+SEQRES   7 B  100  TYR ALA CYS ARG VAL ASN HIS VAL THR LEU SER GLN PRO          
+SEQRES   8 B  100  LYS ILE VAL LYS TRP ASP ARG ASP MET                          
+SEQRES   1 P    9  ASN LEU VAL PRO MET CYS ALA THR VAL                          
+FORMUL   4  HOH   *201(H2 O)                                                    
+HELIX    1   1 ALA A   49  GLU A   55  5                                   7    
+HELIX    2   2 GLY A   56  TYR A   85  1                                  30    
+HELIX    3   3 ASP A 1049  ALA A 1061A 1                                  14    
+HELIX    4   4 HIS A 1062  GLY A 1072A 1                                  12    
+HELIX    5   5 GLY A 1072A GLY A 1085  1                                  14    
+HELIX    6   6 GLY A 1085  GLN A 1090  1                                   6    
+HELIX    7   7 GLN A 2098  GLN A 2100  5                                   3    
+SHEET    1   A 8 GLU A  46  PRO A  47  0                              
+SHEET    2   A 8 THR A  31  ASP A  37 -1  N  ARG A  35   O  GLU A  46 
+SHEET    3   A 8 ARG A  21  VAL A  28 -1  N  GLY A  26   O  PHE A  33 
+SHEET    4   A 8 HIS A   3  VAL A  12 -1  N  ARG A   6   O  TYR A  27 
+SHEET    5   A 8 THR A1004  VAL A1013 -1  O  TYR A1009   N  TYR A   7 
+SHEET    6   A 8 PHE A1019  TYR A1028 -1  O  GLN A1025   N  MET A1008 
+SHEET    7   A 8 LYS A1031  LEU A1036 -1  O  LEU A1036   N  HIS A1024 
+SHEET    8   A 8 TRP A1045  ALA A1047 -1  O  THR A1046   N  ALA A1035 
+SHEET    1   B 4 LYS A2003  ALA A2010  0                              
+SHEET    2   B 4 GLU A2018  PHE A2028 -1  O  TRP A2024   N  HIS A2005 
+SHEET    3   B 4 PHE A2085B PRO A2092 -1  O  VAL A2087   N  CYS A2023 
+SHEET    4   B 4 THR A2078  LEU A2080 -1  N  GLU A2079   O  ALA A2088 
+SHEET    1   C 4 LYS A2003  ALA A2010  0                              
+SHEET    2   C 4 GLU A2018  PHE A2028 -1  O  TRP A2024   N  HIS A2005 
+SHEET    3   C 4 PHE A2085B PRO A2092 -1  O  VAL A2087   N  CYS A2023 
+SHEET    4   C 4 ARG A2084  PRO A2084A-1  N  ARG A2084   O  GLN A2085A
+SHEET    1   D 4 GLU A2045A GLN A2045C 0                              
+SHEET    2   D 4 THR A2038  ARG A2043 -1  N  TRP A2041   O  GLN A2045C
+SHEET    3   D 4 TYR A2102  GLN A2107 -1  O  HIS A2105   N  THR A2040 
+SHEET    4   D 4 LEU A2117  ARG A2120 -1  O  LEU A2119   N  CYS A2104 
+SHEET    1   E 4 LYS B1003  SER B1008  0                              
+SHEET    2   E 4 ASN B1019  PHE B1028 -1  O  SER B1026   N  LYS B1003 
+SHEET    3   E 4 PHE B1085B PHE B1091 -1  O  PHE B1091   N  ASN B1019 
+SHEET    4   E 4 GLU B1079  HIS B1080 -1  N  GLU B1079   O  TYR B1088 
+SHEET    1   F 4 LYS B1003  SER B1008  0                              
+SHEET    2   F 4 ASN B1019  PHE B1028 -1  O  SER B1026   N  LYS B1003 
+SHEET    3   F 4 PHE B1085B PHE B1091 -1  O  PHE B1091   N  ASN B1019 
+SHEET    4   F 4 SER B1084  PHE B1084A-1  N  SER B1084   O  TYR B1085A
+SHEET    1   G 4 GLU B1045A ARG B1045B 0                              
+SHEET    2   G 4 GLU B1038  LYS B1043 -1  N  LYS B1043   O  GLU B1045A
+SHEET    3   G 4 TYR B1102  ASN B1107 -1  O  ARG B1105   N  ASP B1040 
+SHEET    4   G 4 LYS B1117  LYS B1120 -1  O  LYS B1117   N  VAL B1106 
+SSBOND   1 CYS A 1011    CYS A 1074                          1555   1555
+SSBOND   2 CYS A 2023    CYS A 2104                          1555   1555
+SSBOND   3 CYS B 1023    CYS B 1104                          1555   1555
+CISPEP   1 TYR A 2029    PRO A 2030          0         2.36
+CISPEP   2 HIS B 1029    PRO B 1030          0        -0.17
+CRYST1   51.289   79.614   55.080  90.00 111.83  90.00 P 1 21 1      2          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.019497  0.000000  0.007811        0.00000                         
+SCALE2      0.000000  0.012561  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.019558        0.00000                         
+ATOM      1  N   GLY M   1      -9.103 -15.828  18.549  1.00 26.55           N  
+ATOM      2  CA  GLY M   1      -8.215 -14.641  18.722  1.00 23.78           C  
+ATOM      3  C   GLY M   1      -9.006 -13.373  18.443  1.00 22.89           C  
+ATOM      4  O   GLY M   1     -10.099 -13.416  17.875  1.00 21.88           O  
+ATOM      5  N   SER M   2      -8.455 -12.240  18.864  1.00 21.58           N  
+ATOM      6  CA  SER M   2      -9.088 -10.971  18.617  1.00 19.70           C  
+ATOM      7  C   SER M   2      -8.744 -10.478  17.207  1.00 17.38           C  
+ATOM      8  O   SER M   2      -7.767 -10.930  16.601  1.00 17.09           O  
+ATOM      9  CB  SER M   2      -8.642  -9.966  19.666  1.00 20.73           C  
+ATOM     10  OG  SER M   2      -7.232  -9.826  19.665  1.00 23.98           O  
+ATOM     11  N   HIS M   3      -9.552  -9.546  16.707  1.00 13.48           N  
+ATOM     12  CA  HIS M   3      -9.266  -8.850  15.453  1.00 11.22           C  
+ATOM     13  C   HIS M   3      -9.417  -7.360  15.680  1.00 10.87           C  
+ATOM     14  O   HIS M   3     -10.134  -6.943  16.592  1.00 10.72           O  
+ATOM     15  CB  HIS M   3     -10.248  -9.283  14.375  1.00 10.71           C  
+ATOM     16  CG  HIS M   3     -10.103 -10.722  13.986  1.00 11.85           C  
+ATOM     17  ND1 HIS M   3      -9.086 -11.166  13.164  1.00 13.44           N  
+ATOM     18  CD2 HIS M   3     -10.825 -11.818  14.324  1.00 12.31           C  
+ATOM     19  CE1 HIS M   3      -9.209 -12.475  12.987  1.00 14.64           C  
+ATOM     20  NE2 HIS M   3     -10.254 -12.894  13.681  1.00 13.92           N  
+ATOM     21  N   SER M   4      -8.759  -6.553  14.849  1.00 10.60           N  
+ATOM     22  CA ASER M   4      -8.762  -5.101  15.012  0.50 11.17           C  
+ATOM     23  CA BSER M   4      -8.841  -5.110  15.017  0.50 10.20           C  
+ATOM     24  C   SER M   4      -9.143  -4.403  13.704  1.00 10.82           C  
+ATOM     25  O   SER M   4      -8.823  -4.910  12.622  1.00 10.63           O  
+ATOM     26  CB ASER M   4      -7.358  -4.626  15.431  0.50 12.36           C  
+ATOM     27  CB BSER M   4      -7.525  -4.586  15.582  0.50 11.09           C  
+ATOM     28  OG ASER M   4      -7.007  -5.049  16.741  0.50 13.47           O  
+ATOM     29  OG BSER M   4      -6.469  -4.863  14.687  0.50  6.83           O  
+ATOM     30  N   MET M   5      -9.800  -3.250  13.807  1.00 11.40           N  
+ATOM     31  CA  MET M   5      -9.922  -2.332  12.678  1.00 11.51           C  
+ATOM     32  C   MET M   5      -9.282  -1.029  13.143  1.00 12.04           C  
+ATOM     33  O   MET M   5      -9.602  -0.551  14.228  1.00 12.01           O  
+ATOM     34  CB  MET M   5     -11.372  -2.070  12.286  1.00 12.22           C  
+ATOM     35  CG  MET M   5     -11.438  -1.087  11.085  1.00 16.66           C  
+ATOM     36  SD  MET M   5     -13.064  -1.010  10.349  1.00 20.41           S  
+ATOM     37  CE  MET M   5     -13.999  -0.073  11.549  1.00 15.83           C  
+ATOM     38  N   ARG M   6      -8.343  -0.497  12.371  1.00 11.34           N  
+ATOM     39  CA  ARG M   6      -7.673   0.733  12.792  1.00 12.07           C  
+ATOM     40  C   ARG M   6      -7.530   1.651  11.612  1.00 10.10           C  
+ATOM     41  O   ARG M   6      -7.293   1.184  10.484  1.00 11.30           O  
+ATOM     42  CB  ARG M   6      -6.307   0.441  13.381  1.00 13.86           C  
+ATOM     43  CG  ARG M   6      -6.331  -0.382  14.645  1.00 19.83           C  
+ATOM     44  CD  ARG M   6      -4.937  -0.722  15.081  1.00 26.31           C  
+ATOM     45  NE  ARG M   6      -4.804  -0.741  16.540  1.00 33.60           N  
+ATOM     46  CZ  ARG M   6      -3.634  -0.637  17.183  1.00 36.48           C  
+ATOM     47  NH1 ARG M   6      -2.500  -0.509  16.495  1.00 37.48           N  
+ATOM     48  NH2 ARG M   6      -3.594  -0.654  18.513  1.00 38.41           N  
+ATOM     49  N   TYR M   7      -7.698   2.944  11.863  1.00  8.34           N  
+ATOM     50  CA  TYR M   7      -7.429   3.959  10.869  1.00  8.34           C  
+ATOM     51  C   TYR M   7      -6.337   4.894  11.353  1.00  8.92           C  
+ATOM     52  O   TYR M   7      -6.364   5.315  12.521  1.00  7.90           O  
+ATOM     53  CB  TYR M   7      -8.670   4.809  10.600  1.00  9.37           C  
+ATOM     54  CG  TYR M   7      -9.738   4.125   9.761  1.00  8.55           C  
+ATOM     55  CD1 TYR M   7     -10.837   3.512  10.369  1.00 12.51           C  
+ATOM     56  CD2 TYR M   7      -9.666   4.138   8.349  1.00 11.75           C  
+ATOM     57  CE1 TYR M   7     -11.846   2.884   9.605  1.00 10.52           C  
+ATOM     58  CE2 TYR M   7     -10.669   3.526   7.586  1.00 13.10           C  
+ATOM     59  CZ  TYR M   7     -11.756   2.910   8.230  1.00 11.68           C  
+ATOM     60  OH  TYR M   7     -12.772   2.320   7.489  1.00 12.47           O  
+ATOM     61  N   PHE M   8      -5.414   5.224  10.451  1.00  8.56           N  
+ATOM     62  CA  PHE M   8      -4.254   6.053  10.728  1.00  9.09           C  
+ATOM     63  C   PHE M   8      -4.311   7.273   9.820  1.00 10.23           C  
+ATOM     64  O   PHE M   8      -4.607   7.142   8.613  1.00 10.02           O  
+ATOM     65  CB  PHE M   8      -2.972   5.282  10.378  1.00 10.30           C  
+ATOM     66  CG  PHE M   8      -2.758   4.046  11.207  1.00 10.21           C  
+ATOM     67  CD1 PHE M   8      -3.434   2.861  10.904  1.00 11.95           C  
+ATOM     68  CD2 PHE M   8      -1.869   4.055  12.270  1.00 14.54           C  
+ATOM     69  CE1 PHE M   8      -3.235   1.700  11.669  1.00 12.78           C  
+ATOM     70  CE2 PHE M   8      -1.650   2.889  13.044  1.00 14.22           C  
+ATOM     71  CZ  PHE M   8      -2.339   1.729  12.751  1.00 13.66           C  
+ATOM     72  N   PHE M   9      -4.054   8.450  10.393  1.00  9.91           N  
+ATOM     73  CA  PHE M   9      -4.200   9.714   9.665  1.00  9.52           C  
+ATOM     74  C   PHE M   9      -2.983  10.559   9.934  1.00  9.59           C  
+ATOM     75  O   PHE M   9      -2.579  10.706  11.091  1.00 10.31           O  
+ATOM     76  CB  PHE M   9      -5.447  10.513  10.096  1.00  8.54           C  
+ATOM     77  CG  PHE M   9      -6.723   9.721  10.077  1.00  8.54           C  
+ATOM     78  CD1 PHE M   9      -7.118   9.002  11.193  1.00  7.91           C  
+ATOM     79  CD2 PHE M   9      -7.526   9.690   8.947  1.00  8.84           C  
+ATOM     80  CE1 PHE M   9      -8.291   8.238  11.196  1.00  7.94           C  
+ATOM     81  CE2 PHE M   9      -8.723   8.940   8.927  1.00  8.50           C  
+ATOM     82  CZ  PHE M   9      -9.110   8.203  10.055  1.00  9.58           C  
+ATOM     83  N   THR M  10      -2.389  11.094   8.870  1.00  8.81           N  
+ATOM     84  CA  THR M  10      -1.256  12.013   9.012  1.00  9.57           C  
+ATOM     85  C   THR M  10      -1.537  13.278   8.217  1.00 10.01           C  
+ATOM     86  O   THR M  10      -1.834  13.180   7.022  1.00  7.97           O  
+ATOM     87  CB  THR M  10       0.077  11.373   8.480  1.00 10.36           C  
+ATOM     88  OG1 THR M  10       0.352  10.160   9.207  1.00 10.33           O  
+ATOM     89  CG2 THR M  10       1.235  12.325   8.692  1.00  8.03           C  
+ATOM     90  N   SER M  11      -1.443  14.443   8.866  1.00  8.31           N  
+ATOM     91  CA  SER M  11      -1.530  15.716   8.160  1.00 10.64           C  
+ATOM     92  C   SER M  11      -0.271  16.531   8.371  1.00 10.32           C  
+ATOM     93  O   SER M  11       0.162  16.727   9.530  1.00  9.57           O  
+ATOM     94  CB  SER M  11      -2.746  16.527   8.628  1.00 12.25           C  
+ATOM     95  OG  SER M  11      -3.941  15.898   8.194  1.00 15.41           O  
+ATOM     96  N   VAL M  12       0.313  17.010   7.271  1.00  9.49           N  
+ATOM     97  CA  VAL M  12       1.573  17.749   7.346  1.00  9.63           C  
+ATOM     98  C   VAL M  12       1.391  19.142   6.747  1.00 11.07           C  
+ATOM     99  O   VAL M  12       1.116  19.257   5.530  1.00  9.84           O  
+ATOM    100  CB  VAL M  12       2.715  17.021   6.571  1.00 11.36           C  
+ATOM    101  CG1 VAL M  12       4.012  17.814   6.704  1.00 10.16           C  
+ATOM    102  CG2 VAL M  12       2.906  15.585   7.115  1.00  9.93           C  
+ATOM    103  N   SER M  13       1.546  20.187   7.563  1.00 10.86           N  
+ATOM    104  CA  SER M  13       1.340  21.561   7.075  1.00 11.93           C  
+ATOM    105  C   SER M  13       2.390  21.949   6.011  1.00 13.58           C  
+ATOM    106  O   SER M  13       3.502  21.422   5.998  1.00 10.36           O  
+ATOM    107  CB  SER M  13       1.309  22.568   8.244  1.00 13.20           C  
+ATOM    108  OG  SER M  13       2.571  22.665   8.888  1.00 13.19           O  
+ATOM    109  N   ARG M  14       1.994  22.825   5.090  1.00 15.83           N  
+ATOM    110  CA  ARG M  14       2.852  23.273   4.004  1.00 19.57           C  
+ATOM    111  C   ARG M  14       2.855  24.785   4.068  1.00 20.88           C  
+ATOM    112  O   ARG M  14       2.066  25.449   3.385  1.00 21.18           O  
+ATOM    113  CB  ARG M  14       2.286  22.827   2.660  1.00 19.86           C  
+ATOM    114  CG  ARG M  14       2.390  21.348   2.456  1.00 23.09           C  
+ATOM    115  CD  ARG M  14       1.681  20.936   1.183  1.00 25.92           C  
+ATOM    116  NE  ARG M  14       2.206  19.660   0.731  1.00 29.78           N  
+ATOM    117  CZ  ARG M  14       1.726  18.984  -0.307  1.00 31.16           C  
+ATOM    118  NH1 ARG M  14       0.716  19.481  -0.998  1.00 31.96           N  
+ATOM    119  NH2 ARG M  14       2.268  17.820  -0.654  1.00 31.08           N  
+ATOM    120  N   PRO M  15       3.718  25.329   4.918  1.00 22.20           N  
+ATOM    121  CA  PRO M  15       3.723  26.754   5.220  1.00 23.84           C  
+ATOM    122  C   PRO M  15       4.019  27.655   3.999  1.00 23.42           C  
+ATOM    123  O   PRO M  15       3.548  28.790   3.947  1.00 24.79           O  
+ATOM    124  CB  PRO M  15       4.798  26.883   6.309  1.00 24.16           C  
+ATOM    125  CG  PRO M  15       5.640  25.646   6.202  1.00 25.08           C  
+ATOM    126  CD  PRO M  15       4.723  24.571   5.687  1.00 23.49           C  
+ATOM    127  N   GLY M  16       4.766  27.151   3.028  1.00 22.49           N  
+ATOM    128  CA  GLY M  16       5.076  27.932   1.830  1.00 21.79           C  
+ATOM    129  C   GLY M  16       3.842  28.224   0.985  1.00 21.60           C  
+ATOM    130  O   GLY M  16       3.675  29.335   0.504  1.00 20.94           O  
+ATOM    131  N   ARG M  17       2.984  27.216   0.793  1.00 20.00           N  
+ATOM    132  CA  ARG M  17       1.775  27.396   0.000  1.00 18.82           C  
+ATOM    133  C   ARG M  17       0.788  26.239   0.143  1.00 18.99           C  
+ATOM    134  O   ARG M  17       1.185  25.077   0.091  1.00 17.51           O  
+ATOM    135  CB  ARG M  17       2.136  27.527  -1.478  1.00 19.08           C  
+ATOM    136  CG  ARG M  17       0.906  27.577  -2.375  1.00 18.11           C  
+ATOM    137  CD  ARG M  17       1.252  27.632  -3.851  1.00 17.19           C  
+ATOM    138  NE  ARG M  17       1.738  26.353  -4.340  1.00 18.63           N  
+ATOM    139  CZ  ARG M  17       2.948  26.165  -4.837  1.00 17.17           C  
+ATOM    140  NH1 ARG M  17       3.784  27.189  -4.926  1.00 18.17           N  
+ATOM    141  NH2 ARG M  17       3.321  24.960  -5.239  1.00 19.13           N  
+ATOM    142  N   GLY M  18      -0.498  26.562   0.315  1.00 17.61           N  
+ATOM    143  CA  GLY M  18      -1.567  25.566   0.162  1.00 16.63           C  
+ATOM    144  C   GLY M  18      -1.950  24.778   1.401  1.00 16.04           C  
+ATOM    145  O   GLY M  18      -1.458  25.053   2.501  1.00 16.45           O  
+ATOM    146  N   GLU M  19      -2.839  23.811   1.197  1.00 16.14           N  
+ATOM    147  CA AGLU M  19      -3.354  22.991   2.287  0.50 15.73           C  
+ATOM    148  CA BGLU M  19      -3.400  22.953   2.243  0.50 16.09           C  
+ATOM    149  C   GLU M  19      -2.376  21.911   2.698  1.00 15.07           C  
+ATOM    150  O   GLU M  19      -1.471  21.580   1.955  1.00 13.01           O  
+ATOM    151  CB AGLU M  19      -4.660  22.326   1.870  0.50 17.66           C  
+ATOM    152  CB BGLU M  19      -4.656  22.219   1.707  0.50 18.17           C  
+ATOM    153  CG AGLU M  19      -5.854  23.195   2.133  0.50 20.12           C  
+ATOM    154  CG BGLU M  19      -5.968  23.032   1.795  0.50 22.23           C  
+ATOM    155  CD AGLU M  19      -7.053  22.748   1.353  0.50 20.68           C  
+ATOM    156  CD BGLU M  19      -7.177  22.330   1.169  0.50 24.38           C  
+ATOM    157  OE1AGLU M  19      -7.377  21.534   1.403  0.50 21.14           O  
+ATOM    158  OE1BGLU M  19      -6.988  21.550   0.204  0.50 26.06           O  
+ATOM    159  OE2AGLU M  19      -7.658  23.617   0.684  0.50 20.94           O  
+ATOM    160  OE2BGLU M  19      -8.327  22.578   1.627  0.50 25.23           O  
+ATOM    161  N   PRO M  20      -2.555  21.359   3.899  1.00 13.28           N  
+ATOM    162  CA  PRO M  20      -1.664  20.288   4.361  1.00 12.69           C  
+ATOM    163  C   PRO M  20      -1.720  19.048   3.479  1.00 12.66           C  
+ATOM    164  O   PRO M  20      -2.727  18.800   2.784  1.00 14.71           O  
+ATOM    165  CB  PRO M  20      -2.229  19.940   5.746  1.00 13.46           C  
+ATOM    166  CG  PRO M  20      -2.944  21.183   6.177  1.00 14.20           C  
+ATOM    167  CD  PRO M  20      -3.538  21.750   4.925  1.00 14.01           C  
+ATOM    168  N   ARG M  21      -0.639  18.292   3.482  1.00 12.24           N  
+ATOM    169  CA  ARG M  21      -0.611  16.971   2.866  1.00 13.00           C  
+ATOM    170  C   ARG M  21      -1.326  16.034   3.857  1.00 12.84           C  
+ATOM    171  O   ARG M  21      -0.979  16.034   5.046  1.00 13.92           O  
+ATOM    172  CB  ARG M  21       0.850  16.540   2.663  1.00 14.23           C  
+ATOM    173  CG  ARG M  21       1.024  15.083   2.230  1.00 17.25           C  
+ATOM    174  CD  ARG M  21       0.627  14.969   0.788  1.00 20.29           C  
+ATOM    175  NE  ARG M  21       0.723  13.624   0.232  1.00 21.79           N  
+ATOM    176  CZ  ARG M  21       1.855  13.044  -0.151  1.00 23.99           C  
+ATOM    177  NH1 ARG M  21       3.021  13.665   0.004  1.00 23.67           N  
+ATOM    178  NH2 ARG M  21       1.825  11.825  -0.662  1.00 23.41           N  
+ATOM    179  N   PHE M  22      -2.336  15.294   3.385  1.00 11.29           N  
+ATOM    180  CA  PHE M  22      -3.166  14.418   4.233  1.00 11.86           C  
+ATOM    181  C   PHE M  22      -3.195  13.013   3.640  1.00 11.49           C  
+ATOM    182  O   PHE M  22      -3.501  12.826   2.439  1.00 12.58           O  
+ATOM    183  CB  PHE M  22      -4.592  14.986   4.341  1.00 10.27           C  
+ATOM    184  CG  PHE M  22      -5.609  14.060   5.036  1.00 12.39           C  
+ATOM    185  CD1 PHE M  22      -5.631  13.930   6.413  1.00 15.14           C  
+ATOM    186  CD2 PHE M  22      -6.546  13.360   4.293  1.00 13.49           C  
+ATOM    187  CE1 PHE M  22      -6.582  13.111   7.046  1.00 14.21           C  
+ATOM    188  CE2 PHE M  22      -7.509  12.562   4.899  1.00 14.83           C  
+ATOM    189  CZ  PHE M  22      -7.521  12.432   6.291  1.00 15.50           C  
+ATOM    190  N   ILE M  23      -2.821  12.040   4.456  1.00 10.99           N  
+ATOM    191  CA  ILE M  23      -2.828  10.625   4.067  1.00 10.74           C  
+ATOM    192  C   ILE M  23      -3.532   9.804   5.139  1.00 10.24           C  
+ATOM    193  O   ILE M  23      -3.177   9.885   6.347  1.00 11.50           O  
+ATOM    194  CB  ILE M  23      -1.408  10.059   3.903  1.00 11.60           C  
+ATOM    195  CG1 ILE M  23      -0.680  10.796   2.779  1.00 10.52           C  
+ATOM    196  CG2 ILE M  23      -1.462   8.535   3.583  1.00 12.75           C  
+ATOM    197  CD1 ILE M  23       0.761  10.397   2.598  1.00 16.47           C  
+ATOM    198  N   ALA M  24      -4.517   9.023   4.697  1.00  8.33           N  
+ATOM    199  CA  ALA M  24      -5.324   8.195   5.600  1.00  9.20           C  
+ATOM    200  C   ALA M  24      -5.215   6.768   5.107  1.00  9.54           C  
+ATOM    201  O   ALA M  24      -5.310   6.537   3.908  1.00  9.35           O  
+ATOM    202  CB  ALA M  24      -6.754   8.604   5.555  1.00  9.07           C  
+ATOM    203  N   VAL M  25      -5.019   5.827   6.016  1.00  8.78           N  
+ATOM    204  CA AVAL M  25      -4.990   4.421   5.641  0.50  8.22           C  
+ATOM    205  CA BVAL M  25      -4.948   4.415   5.658  0.50  9.54           C  
+ATOM    206  C   VAL M  25      -5.802   3.629   6.649  1.00  9.87           C  
+ATOM    207  O   VAL M  25      -5.773   3.920   7.841  1.00  9.83           O  
+ATOM    208  CB AVAL M  25      -3.560   3.863   5.604  0.50  8.20           C  
+ATOM    209  CB BVAL M  25      -3.497   3.904   5.742  0.50 10.39           C  
+ATOM    210  CG1AVAL M  25      -2.778   4.455   4.431  0.50  7.77           C  
+ATOM    211  CG1BVAL M  25      -3.397   2.458   5.291  0.50 10.92           C  
+ATOM    212  CG2AVAL M  25      -2.842   4.128   6.931  0.50  3.79           C  
+ATOM    213  CG2BVAL M  25      -2.572   4.782   4.911  0.50 10.98           C  
+ATOM    214  N   GLY M  26      -6.522   2.619   6.167  1.00  8.78           N  
+ATOM    215  CA  GLY M  26      -7.320   1.762   7.071  1.00  8.18           C  
+ATOM    216  C   GLY M  26      -6.736   0.354   7.042  1.00  9.65           C  
+ATOM    217  O   GLY M  26      -6.313  -0.105   5.976  1.00  7.68           O  
+ATOM    218  N   TYR M  27      -6.706  -0.313   8.203  1.00  8.66           N  
+ATOM    219  CA  TYR M  27      -6.246  -1.702   8.326  1.00  9.32           C  
+ATOM    220  C   TYR M  27      -7.286  -2.578   9.006  1.00 10.40           C  
+ATOM    221  O   TYR M  27      -7.951  -2.124   9.941  1.00 10.15           O  
+ATOM    222  CB  TYR M  27      -5.014  -1.764   9.227  1.00 10.36           C  
+ATOM    223  CG  TYR M  27      -3.734  -1.295   8.584  1.00 12.61           C  
+ATOM    224  CD1 TYR M  27      -3.404   0.055   8.539  1.00 16.44           C  
+ATOM    225  CD2 TYR M  27      -2.855  -2.208   8.025  1.00 14.65           C  
+ATOM    226  CE1 TYR M  27      -2.212   0.473   7.930  1.00 18.60           C  
+ATOM    227  CE2 TYR M  27      -1.680  -1.812   7.446  1.00 18.37           C  
+ATOM    228  CZ  TYR M  27      -1.360  -0.476   7.398  1.00 20.08           C  
+ATOM    229  OH  TYR M  27      -0.159  -0.106   6.805  1.00 25.59           O  
+ATOM    230  N   VAL M  28      -7.405  -3.833   8.574  1.00  8.39           N  
+ATOM    231  CA  VAL M  28      -8.015  -4.861   9.436  1.00  8.86           C  
+ATOM    232  C   VAL M  28      -6.842  -5.768   9.840  1.00  9.68           C  
+ATOM    233  O   VAL M  28      -6.119  -6.262   8.981  1.00  9.28           O  
+ATOM    234  CB  VAL M  28      -9.159  -5.648   8.742  1.00  7.18           C  
+ATOM    235  CG1 VAL M  28      -9.588  -6.866   9.636  1.00  8.73           C  
+ATOM    236  CG2 VAL M  28     -10.365  -4.716   8.508  1.00  8.83           C  
+ATOM    237  N   ASP M  29      -6.604  -5.896  11.150  1.00  9.98           N  
+ATOM    238  CA  ASP M  29      -5.396  -6.544  11.667  1.00 11.23           C  
+ATOM    239  C   ASP M  29      -4.154  -5.969  10.965  1.00 11.58           C  
+ATOM    240  O   ASP M  29      -3.961  -4.745  10.967  1.00 10.96           O  
+ATOM    241  CB  ASP M  29      -5.495  -8.051  11.485  1.00 13.38           C  
+ATOM    242  CG  ASP M  29      -6.674  -8.640  12.242  1.00 15.71           C  
+ATOM    243  OD1 ASP M  29      -7.294  -9.614  11.760  1.00 17.77           O  
+ATOM    244  OD2 ASP M  29      -6.972  -8.130  13.338  1.00 16.20           O  
+ATOM    245  N   ASP M  30      -3.351  -6.823  10.334  1.00 10.26           N  
+ATOM    246  CA  ASP M  30      -2.154  -6.315   9.643  1.00 11.85           C  
+ATOM    247  C   ASP M  30      -2.352  -6.109   8.136  1.00 12.18           C  
+ATOM    248  O   ASP M  30      -1.357  -5.987   7.388  1.00 12.76           O  
+ATOM    249  CB  ASP M  30      -0.949  -7.255   9.849  1.00 12.13           C  
+ATOM    250  CG  ASP M  30      -0.447  -7.267  11.291  1.00 14.64           C  
+ATOM    251  OD1 ASP M  30      -0.483  -6.213  11.969  1.00 17.63           O  
+ATOM    252  OD2 ASP M  30      -0.021  -8.335  11.748  1.00 15.13           O  
+ATOM    253  N   THR M  31      -3.598  -6.057   7.687  1.00 10.19           N  
+ATOM    254  CA  THR M  31      -3.887  -5.904   6.234  1.00  9.59           C  
+ATOM    255  C   THR M  31      -4.433  -4.511   5.904  1.00 10.48           C  
+ATOM    256  O   THR M  31      -5.481  -4.130   6.425  1.00  9.65           O  
+ATOM    257  CB  THR M  31      -4.954  -6.936   5.801  1.00 11.05           C  
+ATOM    258  OG1 THR M  31      -4.469  -8.262   6.062  1.00 12.29           O  
+ATOM    259  CG2 THR M  31      -5.316  -6.796   4.305  1.00 10.81           C  
+ATOM    260  N   GLN M  32      -3.743  -3.739   5.059  1.00  9.93           N  
+ATOM    261  CA AGLN M  32      -4.311  -2.466   4.622  0.50 10.36           C  
+ATOM    262  CA BGLN M  32      -4.286  -2.465   4.581  0.50 10.28           C  
+ATOM    263  C   GLN M  32      -5.485  -2.724   3.670  1.00 10.81           C  
+ATOM    264  O   GLN M  32      -5.415  -3.607   2.815  1.00 10.09           O  
+ATOM    265  CB AGLN M  32      -3.255  -1.561   3.968  0.50 11.28           C  
+ATOM    266  CB BGLN M  32      -3.218  -1.694   3.799  0.50 10.82           C  
+ATOM    267  CG AGLN M  32      -3.725  -0.096   3.884  0.50 10.59           C  
+ATOM    268  CG BGLN M  32      -3.702  -0.329   3.279  0.50 10.65           C  
+ATOM    269  CD AGLN M  32      -2.839   0.796   3.034  0.50 12.56           C  
+ATOM    270  CD BGLN M  32      -2.762   0.251   2.245  0.50 11.86           C  
+ATOM    271  OE1AGLN M  32      -1.667   0.497   2.795  0.50 11.25           O  
+ATOM    272  OE1BGLN M  32      -1.865  -0.434   1.757  0.50 13.61           O  
+ATOM    273  NE2AGLN M  32      -3.396   1.915   2.588  0.50 11.58           N  
+ATOM    274  NE2BGLN M  32      -2.948   1.519   1.923  0.50 12.43           N  
+ATOM    275  N   PHE M  33      -6.584  -1.974   3.836  1.00  8.45           N  
+ATOM    276  CA  PHE M  33      -7.742  -2.180   2.950  1.00  9.44           C  
+ATOM    277  C   PHE M  33      -8.254  -0.929   2.267  1.00  8.99           C  
+ATOM    278  O   PHE M  33      -8.967  -1.023   1.271  1.00  8.15           O  
+ATOM    279  CB  PHE M  33      -8.908  -2.948   3.622  1.00  9.29           C  
+ATOM    280  CG  PHE M  33      -9.645  -2.161   4.651  1.00 10.54           C  
+ATOM    281  CD1 PHE M  33      -9.082  -1.927   5.908  1.00 11.00           C  
+ATOM    282  CD2 PHE M  33     -10.918  -1.657   4.379  1.00  9.42           C  
+ATOM    283  CE1 PHE M  33      -9.781  -1.187   6.890  1.00 10.04           C  
+ATOM    284  CE2 PHE M  33     -11.608  -0.929   5.333  1.00 11.29           C  
+ATOM    285  CZ  PHE M  33     -11.033  -0.698   6.604  1.00 11.06           C  
+ATOM    286  N   VAL M  34      -7.904   0.247   2.780  1.00  8.71           N  
+ATOM    287  CA  VAL M  34      -8.297   1.456   2.065  1.00  9.87           C  
+ATOM    288  C   VAL M  34      -7.226   2.512   2.227  1.00 11.15           C  
+ATOM    289  O   VAL M  34      -6.441   2.473   3.191  1.00 10.02           O  
+ATOM    290  CB  VAL M  34      -9.650   2.027   2.544  1.00 10.31           C  
+ATOM    291  CG1 VAL M  34     -10.801   1.099   2.197  1.00 12.02           C  
+ATOM    292  CG2 VAL M  34      -9.637   2.276   4.077  1.00 12.52           C  
+ATOM    293  N   ARG M  35      -7.246   3.498   1.332  1.00 12.01           N  
+ATOM    294  CA  ARG M  35      -6.403   4.668   1.511  1.00 12.76           C  
+ATOM    295  C   ARG M  35      -6.994   5.938   0.891  1.00 13.05           C  
+ATOM    296  O   ARG M  35      -7.821   5.891  -0.028  1.00 12.54           O  
+ATOM    297  CB  ARG M  35      -5.008   4.410   0.931  1.00 15.36           C  
+ATOM    298  CG  ARG M  35      -5.044   4.035  -0.526  1.00 19.85           C  
+ATOM    299  CD  ARG M  35      -4.874   5.229  -1.447  1.00 24.41           C  
+ATOM    300  NE  ARG M  35      -3.474   5.583  -1.583  1.00 28.39           N  
+ATOM    301  CZ  ARG M  35      -2.947   6.236  -2.618  1.00 30.63           C  
+ATOM    302  NH1 ARG M  35      -3.710   6.626  -3.640  1.00 32.41           N  
+ATOM    303  NH2 ARG M  35      -1.647   6.502  -2.624  1.00 28.88           N  
+ATOM    304  N   PHE M  36      -6.541   7.072   1.402  1.00 11.78           N  
+ATOM    305  CA  PHE M  36      -6.824   8.348   0.788  1.00 13.05           C  
+ATOM    306  C   PHE M  36      -5.530   9.152   0.825  1.00 13.72           C  
+ATOM    307  O   PHE M  36      -4.844   9.201   1.842  1.00 12.54           O  
+ATOM    308  CB  PHE M  36      -7.946   9.088   1.518  1.00 13.76           C  
+ATOM    309  CG  PHE M  36      -8.301  10.412   0.884  1.00 14.82           C  
+ATOM    310  CD1 PHE M  36      -9.302  10.490  -0.074  1.00 16.28           C  
+ATOM    311  CD2 PHE M  36      -7.597  11.569   1.221  1.00 18.16           C  
+ATOM    312  CE1 PHE M  36      -9.621  11.714  -0.676  1.00 17.69           C  
+ATOM    313  CE2 PHE M  36      -7.896  12.787   0.613  1.00 19.59           C  
+ATOM    314  CZ  PHE M  36      -8.918  12.858  -0.325  1.00 18.21           C  
+ATOM    315  N   ASP M  37      -5.165   9.764  -0.292  1.00 14.18           N  
+ATOM    316  CA  ASP M  37      -4.005  10.663  -0.291  1.00 14.84           C  
+ATOM    317  C   ASP M  37      -4.455  11.963  -0.925  1.00 16.12           C  
+ATOM    318  O   ASP M  37      -4.905  11.955  -2.071  1.00 15.02           O  
+ATOM    319  CB  ASP M  37      -2.837  10.043  -1.090  1.00 15.43           C  
+ATOM    320  CG  ASP M  37      -1.521  10.861  -1.001  1.00 19.18           C  
+ATOM    321  OD1 ASP M  37      -1.549  12.108  -0.818  1.00 18.83           O  
+ATOM    322  OD2 ASP M  37      -0.441  10.226  -1.116  1.00 18.71           O  
+ATOM    323  N   SER M  38      -4.335  13.067  -0.195  1.00 16.13           N  
+ATOM    324  CA  SER M  38      -4.758  14.379  -0.702  1.00 19.78           C  
+ATOM    325  C   SER M  38      -4.034  14.753  -2.007  1.00 20.27           C  
+ATOM    326  O   SER M  38      -4.536  15.566  -2.796  1.00 21.21           O  
+ATOM    327  CB  SER M  38      -4.505  15.465   0.355  1.00 17.52           C  
+ATOM    328  OG  SER M  38      -3.115  15.557   0.597  1.00 19.40           O  
+ATOM    329  N   ASP M  39      -2.866  14.164  -2.228  1.00 20.70           N  
+ATOM    330  CA  ASP M  39      -2.064  14.491  -3.406  1.00 24.27           C  
+ATOM    331  C   ASP M  39      -2.454  13.663  -4.639  1.00 23.48           C  
+ATOM    332  O   ASP M  39      -2.005  13.941  -5.736  1.00 23.27           O  
+ATOM    333  CB  ASP M  39      -0.561  14.373  -3.112  1.00 26.00           C  
+ATOM    334  CG  ASP M  39       0.067  15.712  -2.715  1.00 29.88           C  
+ATOM    335  OD1 ASP M  39      -0.670  16.644  -2.304  1.00 32.10           O  
+ATOM    336  OD2 ASP M  39       1.302  15.835  -2.820  1.00 32.71           O  
+ATOM    337  N   ALA M  40      -3.311  12.662  -4.455  1.00 22.71           N  
+ATOM    338  CA  ALA M  40      -3.802  11.849  -5.564  1.00 22.53           C  
+ATOM    339  C   ALA M  40      -4.909  12.562  -6.330  1.00 22.59           C  
+ATOM    340  O   ALA M  40      -5.725  13.283  -5.753  1.00 21.66           O  
+ATOM    341  CB  ALA M  40      -4.306  10.507  -5.050  1.00 22.95           C  
+ATOM    342  N   ALA M  41      -4.967  12.328  -7.634  1.00 22.67           N  
+ATOM    343  CA  ALA M  41      -5.942  13.027  -8.467  1.00 22.49           C  
+ATOM    344  C   ALA M  41      -7.388  12.543  -8.267  1.00 21.98           C  
+ATOM    345  O   ALA M  41      -8.315  13.324  -8.411  1.00 20.69           O  
+ATOM    346  CB  ALA M  41      -5.531  12.954  -9.964  1.00 23.97           C  
+ATOM    347  N   SER M  42      -7.585  11.277  -7.918  1.00 20.83           N  
+ATOM    348  CA  SER M  42      -8.949  10.745  -7.794  1.00 21.10           C  
+ATOM    349  C   SER M  42      -9.780  11.489  -6.748  1.00 21.40           C  
+ATOM    350  O   SER M  42     -10.989  11.581  -6.895  1.00 21.52           O  
+ATOM    351  CB  SER M  42      -8.947   9.243  -7.471  1.00 21.92           C  
+ATOM    352  OG  SER M  42      -8.609   8.997  -6.102  1.00 21.64           O  
+ATOM    353  N   GLN M  43      -9.131  11.992  -5.691  1.00 20.32           N  
+ATOM    354  CA  GLN M  43      -9.848  12.618  -4.573  1.00 19.75           C  
+ATOM    355  C   GLN M  43     -10.933  11.695  -4.015  1.00 19.46           C  
+ATOM    356  O   GLN M  43     -12.003  12.151  -3.607  1.00 21.05           O  
+ATOM    357  CB  GLN M  43     -10.445  13.986  -4.965  1.00 19.38           C  
+ATOM    358  CG  GLN M  43      -9.395  15.081  -5.244  1.00 18.18           C  
+ATOM    359  CD  GLN M  43      -8.529  15.413  -4.042  1.00 18.73           C  
+ATOM    360  OE1 GLN M  43      -9.029  15.907  -3.028  1.00 20.27           O  
+ATOM    361  NE2 GLN M  43      -7.210  15.155  -4.151  1.00 15.06           N  
+ATOM    362  N   ARG M  44     -10.658  10.392  -4.002  1.00 18.87           N  
+ATOM    363  CA  ARG M  44     -11.604   9.409  -3.486  1.00 18.22           C  
+ATOM    364  C   ARG M  44     -10.887   8.477  -2.512  1.00 16.04           C  
+ATOM    365  O   ARG M  44      -9.709   8.210  -2.667  1.00 12.79           O  
+ATOM    366  CB  ARG M  44     -12.156   8.518  -4.622  1.00 20.75           C  
+ATOM    367  CG  ARG M  44     -12.660   9.235  -5.884  1.00 27.05           C  
+ATOM    368  CD  ARG M  44     -14.027   9.861  -5.658  1.00 33.33           C  
+ATOM    369  NE  ARG M  44     -15.070   8.858  -5.403  1.00 37.31           N  
+ATOM    370  CZ  ARG M  44     -16.242   9.132  -4.829  1.00 37.70           C  
+ATOM    371  NH1 ARG M  44     -16.520  10.370  -4.451  1.00 38.71           N  
+ATOM    372  NH2 ARG M  44     -17.130   8.172  -4.623  1.00 38.87           N  
+ATOM    373  N   MET M  45     -11.610   7.952  -1.528  1.00 15.48           N  
+ATOM    374  CA  MET M  45     -11.114   6.771  -0.831  1.00 15.49           C  
+ATOM    375  C   MET M  45     -10.991   5.653  -1.877  1.00 16.25           C  
+ATOM    376  O   MET M  45     -11.925   5.455  -2.679  1.00 16.02           O  
+ATOM    377  CB  MET M  45     -12.085   6.361   0.262  1.00 15.38           C  
+ATOM    378  CG  MET M  45     -11.537   5.274   1.186  1.00 17.21           C  
+ATOM    379  SD  MET M  45     -10.328   5.952   2.339  1.00 17.27           S  
+ATOM    380  CE  MET M  45     -11.422   6.386   3.709  1.00 16.71           C  
+ATOM    381  N   GLU M  46      -9.869   4.929  -1.841  1.00 15.06           N  
+ATOM    382  CA  GLU M  46      -9.544   3.858  -2.785  1.00 16.68           C  
+ATOM    383  C   GLU M  46      -9.326   2.506  -2.093  1.00 15.82           C  
+ATOM    384  O   GLU M  46      -8.710   2.462  -1.027  1.00 14.60           O  
+ATOM    385  CB  GLU M  46      -8.253   4.213  -3.517  1.00 17.35           C  
+ATOM    386  CG  GLU M  46      -8.351   5.450  -4.393  1.00 22.59           C  
+ATOM    387  CD  GLU M  46      -7.006   5.929  -4.885  1.00 26.30           C  
+ATOM    388  OE1 GLU M  46      -6.855   7.150  -5.080  1.00 30.91           O  
+ATOM    389  OE2 GLU M  46      -6.096   5.097  -5.087  1.00 28.84           O  
+ATOM    390  N   PRO M  47      -9.790   1.409  -2.715  1.00 15.35           N  
+ATOM    391  CA  PRO M  47      -9.600   0.064  -2.158  1.00 15.68           C  
+ATOM    392  C   PRO M  47      -8.158  -0.422  -2.265  1.00 15.52           C  
+ATOM    393  O   PRO M  47      -7.471  -0.118  -3.234  1.00 16.66           O  
+ATOM    394  CB  PRO M  47     -10.489  -0.821  -3.043  1.00 15.66           C  
+ATOM    395  CG  PRO M  47     -10.571  -0.072  -4.364  1.00 17.48           C  
+ATOM    396  CD  PRO M  47     -10.554   1.394  -3.987  1.00 16.69           C  
+ATOM    397  N   ARG M  48      -7.712  -1.187  -1.275  1.00 15.78           N  
+ATOM    398  CA  ARG M  48      -6.367  -1.742  -1.263  1.00 16.07           C  
+ATOM    399  C   ARG M  48      -6.404  -3.241  -0.958  1.00 17.34           C  
+ATOM    400  O   ARG M  48      -5.370  -3.884  -0.880  1.00 18.10           O  
+ATOM    401  CB  ARG M  48      -5.493  -1.014  -0.230  1.00 17.68           C  
+ATOM    402  CG  ARG M  48      -4.940   0.320  -0.719  1.00 21.86           C  
+ATOM    403  CD  ARG M  48      -4.066   0.067  -1.949  1.00 25.04           C  
+ATOM    404  NE  ARG M  48      -3.444   1.279  -2.475  1.00 31.40           N  
+ATOM    405  CZ  ARG M  48      -3.958   2.037  -3.446  1.00 33.17           C  
+ATOM    406  NH1 ARG M  48      -3.311   3.129  -3.849  1.00 35.26           N  
+ATOM    407  NH2 ARG M  48      -5.121   1.721  -4.013  1.00 34.21           N  
+ATOM    408  N   ALA M  49      -7.605  -3.787  -0.780  1.00 17.62           N  
+ATOM    409  CA  ALA M  49      -7.774  -5.229  -0.596  1.00 18.03           C  
+ATOM    410  C   ALA M  49      -8.969  -5.721  -1.428  1.00 18.05           C  
+ATOM    411  O   ALA M  49      -9.965  -5.010  -1.562  1.00 18.93           O  
+ATOM    412  CB  ALA M  49      -7.969  -5.540   0.870  1.00 18.17           C  
+ATOM    413  N   PRO M  50      -8.873  -6.936  -2.012  1.00 19.22           N  
+ATOM    414  CA  PRO M  50      -9.957  -7.359  -2.915  1.00 18.99           C  
+ATOM    415  C   PRO M  50     -11.336  -7.418  -2.230  1.00 19.17           C  
+ATOM    416  O   PRO M  50     -12.355  -7.121  -2.862  1.00 17.54           O  
+ATOM    417  CB  PRO M  50      -9.519  -8.766  -3.361  1.00 19.55           C  
+ATOM    418  CG  PRO M  50      -8.562  -9.239  -2.266  1.00 20.89           C  
+ATOM    419  CD  PRO M  50      -7.822  -7.965  -1.882  1.00 18.58           C  
+ATOM    420  N   TRP M  51     -11.371  -7.787  -0.953  1.00 16.82           N  
+ATOM    421  CA  TRP M  51     -12.646  -8.035  -0.305  1.00 17.50           C  
+ATOM    422  C   TRP M  51     -13.422  -6.739  -0.010  1.00 16.14           C  
+ATOM    423  O   TRP M  51     -14.611  -6.783   0.226  1.00 18.04           O  
+ATOM    424  CB  TRP M  51     -12.460  -8.852   0.982  1.00 17.71           C  
+ATOM    425  CG  TRP M  51     -11.334  -8.355   1.872  1.00 17.03           C  
+ATOM    426  CD1 TRP M  51     -10.043  -8.818   1.907  1.00 17.28           C  
+ATOM    427  CD2 TRP M  51     -11.407  -7.305   2.844  1.00 16.23           C  
+ATOM    428  NE1 TRP M  51      -9.307  -8.121   2.844  1.00 16.48           N  
+ATOM    429  CE2 TRP M  51     -10.123  -7.181   3.426  1.00 17.69           C  
+ATOM    430  CE3 TRP M  51     -12.437  -6.459   3.284  1.00 16.74           C  
+ATOM    431  CZ2 TRP M  51      -9.836  -6.233   4.424  1.00 14.91           C  
+ATOM    432  CZ3 TRP M  51     -12.141  -5.510   4.275  1.00 15.54           C  
+ATOM    433  CH2 TRP M  51     -10.854  -5.415   4.828  1.00 13.66           C  
+ATOM    434  N   ILE M  52     -12.749  -5.596   0.014  1.00 15.61           N  
+ATOM    435  CA  ILE M  52     -13.472  -4.350   0.233  1.00 14.87           C  
+ATOM    436  C   ILE M  52     -14.135  -3.861  -1.067  1.00 16.36           C  
+ATOM    437  O   ILE M  52     -15.055  -3.055  -1.035  1.00 15.88           O  
+ATOM    438  CB  ILE M  52     -12.583  -3.234   0.844  1.00 13.98           C  
+ATOM    439  CG1 ILE M  52     -13.473  -2.123   1.415  1.00 13.26           C  
+ATOM    440  CG2 ILE M  52     -11.643  -2.663  -0.200  1.00 13.93           C  
+ATOM    441  CD1 ILE M  52     -14.198  -2.490   2.727  1.00 14.50           C  
+ATOM    442  N   GLU M  53     -13.679  -4.386  -2.198  1.00 17.15           N  
+ATOM    443  CA  GLU M  53     -14.358  -4.151  -3.477  1.00 21.46           C  
+ATOM    444  C   GLU M  53     -15.745  -4.792  -3.584  1.00 22.41           C  
+ATOM    445  O   GLU M  53     -16.499  -4.498  -4.507  1.00 22.87           O  
+ATOM    446  CB  GLU M  53     -13.443  -4.547  -4.633  1.00 22.69           C  
+ATOM    447  CG  GLU M  53     -12.224  -3.642  -4.691  1.00 27.70           C  
+ATOM    448  CD  GLU M  53     -11.220  -4.021  -5.771  1.00 30.78           C  
+ATOM    449  OE1 GLU M  53     -11.630  -4.380  -6.895  1.00 32.64           O  
+ATOM    450  OE2 GLU M  53     -10.011  -3.943  -5.489  1.00 33.07           O  
+ATOM    451  N   GLN M  54     -16.090  -5.652  -2.632  1.00 22.96           N  
+ATOM    452  CA  GLN M  54     -17.451  -6.178  -2.541  1.00 24.89           C  
+ATOM    453  C   GLN M  54     -18.451  -5.072  -2.181  1.00 24.69           C  
+ATOM    454  O   GLN M  54     -19.656  -5.215  -2.408  1.00 25.70           O  
+ATOM    455  CB  GLN M  54     -17.526  -7.295  -1.502  1.00 25.65           C  
+ATOM    456  CG  GLN M  54     -16.626  -8.493  -1.844  1.00 27.36           C  
+ATOM    457  CD  GLN M  54     -16.689  -9.592  -0.799  1.00 27.57           C  
+ATOM    458  OE1 GLN M  54     -17.723  -9.782  -0.154  1.00 28.32           O  
+ATOM    459  NE2 GLN M  54     -15.588 -10.327  -0.631  1.00 24.73           N  
+ATOM    460  N   GLU M  55     -17.961  -3.981  -1.604  1.00 23.90           N  
+ATOM    461  CA  GLU M  55     -18.840  -2.868  -1.226  1.00 24.44           C  
+ATOM    462  C   GLU M  55     -19.169  -2.007  -2.458  1.00 24.59           C  
+ATOM    463  O   GLU M  55     -18.286  -1.738  -3.291  1.00 25.57           O  
+ATOM    464  CB  GLU M  55     -18.176  -1.995  -0.153  1.00 24.60           C  
+ATOM    465  CG  GLU M  55     -17.792  -2.726   1.144  1.00 24.25           C  
+ATOM    466  CD  GLU M  55     -18.995  -3.283   1.893  1.00 27.07           C  
+ATOM    467  OE1 GLU M  55     -20.123  -2.732   1.755  1.00 24.78           O  
+ATOM    468  OE2 GLU M  55     -18.812  -4.282   2.622  1.00 26.43           O  
+ATOM    469  N   GLY M  56     -20.422  -1.554  -2.549  1.00 23.59           N  
+ATOM    470  CA  GLY M  56     -20.899  -0.794  -3.711  1.00 22.41           C  
+ATOM    471  C   GLY M  56     -20.567   0.689  -3.726  1.00 22.64           C  
+ATOM    472  O   GLY M  56     -19.917   1.204  -2.811  1.00 21.94           O  
+ATOM    473  N   PRO M  57     -21.055   1.409  -4.758  1.00 21.79           N  
+ATOM    474  CA  PRO M  57     -20.773   2.842  -4.933  1.00 20.97           C  
+ATOM    475  C   PRO M  57     -21.126   3.684  -3.707  1.00 19.83           C  
+ATOM    476  O   PRO M  57     -20.476   4.685  -3.449  1.00 20.05           O  
+ATOM    477  CB  PRO M  57     -21.698   3.246  -6.095  1.00 21.63           C  
+ATOM    478  CG  PRO M  57     -22.019   1.961  -6.809  1.00 21.41           C  
+ATOM    479  CD  PRO M  57     -22.039   0.906  -5.739  1.00 21.58           C  
+ATOM    480  N   GLU M  58     -22.162   3.281  -2.975  1.00 19.39           N  
+ATOM    481  CA  GLU M  58     -22.618   4.014  -1.787  1.00 19.04           C  
+ATOM    482  C   GLU M  58     -21.539   4.026  -0.683  1.00 18.34           C  
+ATOM    483  O   GLU M  58     -21.415   4.986   0.097  1.00 16.38           O  
+ATOM    484  CB  GLU M  58     -23.947   3.415  -1.263  1.00 20.50           C  
+ATOM    485  CG  GLU M  58     -23.888   2.040  -0.573  1.00 22.39           C  
+ATOM    486  CD  GLU M  58     -23.591   0.879  -1.521  1.00 24.95           C  
+ATOM    487  OE1 GLU M  58     -22.984  -0.131  -1.077  1.00 25.61           O  
+ATOM    488  OE2 GLU M  58     -23.948   0.973  -2.715  1.00 26.82           O  
+ATOM    489  N   TYR M  59     -20.756   2.953  -0.631  1.00 15.61           N  
+ATOM    490  CA  TYR M  59     -19.681   2.857   0.346  1.00 15.57           C  
+ATOM    491  C   TYR M  59     -18.593   3.876   0.030  1.00 14.48           C  
+ATOM    492  O   TYR M  59     -18.217   4.683   0.874  1.00 17.02           O  
+ATOM    493  CB  TYR M  59     -19.096   1.428   0.362  1.00 14.23           C  
+ATOM    494  CG  TYR M  59     -17.965   1.253   1.363  1.00 14.20           C  
+ATOM    495  CD1 TYR M  59     -18.230   0.963   2.697  1.00 13.94           C  
+ATOM    496  CD2 TYR M  59     -16.626   1.369   0.962  1.00 12.21           C  
+ATOM    497  CE1 TYR M  59     -17.180   0.795   3.626  1.00 13.61           C  
+ATOM    498  CE2 TYR M  59     -15.593   1.209   1.855  1.00 11.89           C  
+ATOM    499  CZ  TYR M  59     -15.864   0.925   3.181  1.00 12.24           C  
+ATOM    500  OH  TYR M  59     -14.808   0.768   4.051  1.00 12.50           O  
+ATOM    501  N   TRP M  60     -18.097   3.848  -1.198  1.00 14.76           N  
+ATOM    502  CA  TRP M  60     -17.010   4.729  -1.594  1.00 16.10           C  
+ATOM    503  C   TRP M  60     -17.372   6.205  -1.480  1.00 17.97           C  
+ATOM    504  O   TRP M  60     -16.546   7.029  -1.067  1.00 18.36           O  
+ATOM    505  CB  TRP M  60     -16.512   4.331  -2.982  1.00 15.97           C  
+ATOM    506  CG  TRP M  60     -16.071   2.897  -2.938  1.00 15.58           C  
+ATOM    507  CD1 TRP M  60     -16.705   1.819  -3.476  1.00 14.89           C  
+ATOM    508  CD2 TRP M  60     -14.936   2.389  -2.230  1.00 14.93           C  
+ATOM    509  NE1 TRP M  60     -16.009   0.666  -3.174  1.00 14.91           N  
+ATOM    510  CE2 TRP M  60     -14.920   0.991  -2.407  1.00 15.59           C  
+ATOM    511  CE3 TRP M  60     -13.919   2.991  -1.466  1.00 15.68           C  
+ATOM    512  CZ2 TRP M  60     -13.917   0.166  -1.848  1.00 12.72           C  
+ATOM    513  CZ3 TRP M  60     -12.924   2.183  -0.914  1.00 13.61           C  
+ATOM    514  CH2 TRP M  60     -12.930   0.779  -1.115  1.00 15.43           C  
+ATOM    515  N   ASP M  61     -18.614   6.527  -1.831  1.00 17.93           N  
+ATOM    516  CA AASP M  61     -19.132   7.881  -1.659  0.50 18.48           C  
+ATOM    517  CA BASP M  61     -19.133   7.882  -1.658  0.50 18.63           C  
+ATOM    518  C   ASP M  61     -19.162   8.307  -0.189  1.00 17.27           C  
+ATOM    519  O   ASP M  61     -18.697   9.393   0.163  1.00 17.71           O  
+ATOM    520  CB AASP M  61     -20.539   7.986  -2.265  0.50 19.24           C  
+ATOM    521  CB BASP M  61     -20.551   7.996  -2.231  0.50 19.64           C  
+ATOM    522  CG AASP M  61     -20.513   8.062  -3.778  0.50 20.35           C  
+ATOM    523  CG BASP M  61     -21.070   9.420  -2.195  0.50 21.10           C  
+ATOM    524  OD1AASP M  61     -21.600   8.179  -4.385  0.50 20.79           O  
+ATOM    525  OD1BASP M  61     -20.786  10.183  -3.142  0.50 23.07           O  
+ATOM    526  OD2AASP M  61     -19.406   8.001  -4.362  0.50 21.00           O  
+ATOM    527  OD2BASP M  61     -21.751   9.775  -1.215  0.50 21.37           O  
+ATOM    528  N   GLY M  62     -19.719   7.459   0.670  1.00 17.21           N  
+ATOM    529  CA  GLY M  62     -19.847   7.807   2.096  1.00 17.48           C  
+ATOM    530  C   GLY M  62     -18.476   7.906   2.766  1.00 16.82           C  
+ATOM    531  O   GLY M  62     -18.201   8.835   3.534  1.00 17.49           O  
+ATOM    532  N   GLU M  63     -17.593   6.962   2.460  1.00 15.19           N  
+ATOM    533  CA  GLU M  63     -16.244   6.999   3.038  1.00 14.59           C  
+ATOM    534  C   GLU M  63     -15.441   8.202   2.555  1.00 14.38           C  
+ATOM    535  O   GLU M  63     -14.690   8.793   3.335  1.00 13.98           O  
+ATOM    536  CB  GLU M  63     -15.489   5.678   2.806  1.00 14.94           C  
+ATOM    537  CG  GLU M  63     -16.181   4.494   3.492  1.00 16.45           C  
+ATOM    538  CD  GLU M  63     -16.396   4.692   4.996  1.00 17.08           C  
+ATOM    539  OE1 GLU M  63     -17.556   4.741   5.449  1.00 16.56           O  
+ATOM    540  OE2 GLU M  63     -15.408   4.780   5.747  1.00 17.42           O  
+ATOM    541  N   THR M  64     -15.625   8.591   1.291  1.00 14.74           N  
+ATOM    542  CA  THR M  64     -14.927   9.755   0.743  1.00 15.93           C  
+ATOM    543  C   THR M  64     -15.386  11.051   1.406  1.00 16.44           C  
+ATOM    544  O   THR M  64     -14.556  11.902   1.741  1.00 16.77           O  
+ATOM    545  CB  THR M  64     -15.073   9.852  -0.808  1.00 17.19           C  
+ATOM    546  OG1 THR M  64     -14.518   8.675  -1.394  1.00 16.89           O  
+ATOM    547  CG2 THR M  64     -14.315  11.085  -1.365  1.00 16.86           C  
+ATOM    548  N   ARG M  65     -16.702  11.210   1.601  1.00 15.79           N  
+ATOM    549  CA AARG M  65     -17.196  12.412   2.250  0.50 16.17           C  
+ATOM    550  CA BARG M  65     -17.238  12.383   2.277  0.50 15.84           C  
+ATOM    551  C   ARG M  65     -16.603  12.520   3.661  1.00 16.01           C  
+ATOM    552  O   ARG M  65     -16.162  13.596   4.066  1.00 14.27           O  
+ATOM    553  CB AARG M  65     -18.737  12.446   2.284  0.50 17.43           C  
+ATOM    554  CB BARG M  65     -18.768  12.267   2.420  0.50 16.44           C  
+ATOM    555  CG AARG M  65     -19.334  13.802   2.686  0.50 18.68           C  
+ATOM    556  CG BARG M  65     -19.368  13.206   3.466  0.50 16.92           C  
+ATOM    557  CD AARG M  65     -20.860  13.837   2.483  0.50 21.03           C  
+ATOM    558  CD BARG M  65     -20.873  12.959   3.696  0.50 17.59           C  
+ATOM    559  NE AARG M  65     -21.484  12.580   2.891  0.50 22.24           N  
+ATOM    560  NE BARG M  65     -21.215  11.536   3.741  0.50 19.39           N  
+ATOM    561  CZ AARG M  65     -21.841  11.608   2.054  0.50 22.63           C  
+ATOM    562  CZ BARG M  65     -21.376  10.842   4.862  0.50 19.70           C  
+ATOM    563  NH1AARG M  65     -21.656  11.750   0.745  0.50 23.78           N  
+ATOM    564  NH1BARG M  65     -21.237  11.441   6.039  0.50 20.09           N  
+ATOM    565  NH2AARG M  65     -22.390  10.494   2.525  0.50 21.74           N  
+ATOM    566  NH2BARG M  65     -21.677   9.554   4.805  0.50 19.09           N  
+ATOM    567  N   LYS M  66     -16.582  11.415   4.396  1.00 15.06           N  
+ATOM    568  CA  LYS M  66     -16.063  11.449   5.764  1.00 15.08           C  
+ATOM    569  C   LYS M  66     -14.569  11.721   5.810  1.00 14.21           C  
+ATOM    570  O   LYS M  66     -14.093  12.510   6.669  1.00 13.48           O  
+ATOM    571  CB  LYS M  66     -16.419  10.165   6.538  1.00 15.41           C  
+ATOM    572  CG  LYS M  66     -17.899  10.092   6.946  1.00 15.87           C  
+ATOM    573  CD  LYS M  66     -18.237   8.788   7.663  1.00 17.18           C  
+ATOM    574  CE  LYS M  66     -18.129   7.599   6.720  1.00 16.91           C  
+ATOM    575  NZ  LYS M  66     -18.457   6.337   7.439  1.00 17.47           N  
+ATOM    576  N   VAL M  67     -13.821  11.107   4.894  1.00 13.66           N  
+ATOM    577  CA  VAL M  67     -12.368  11.240   4.962  1.00 12.97           C  
+ATOM    578  C   VAL M  67     -11.943  12.653   4.533  1.00 14.07           C  
+ATOM    579  O   VAL M  67     -10.978  13.217   5.060  1.00 12.25           O  
+ATOM    580  CB  VAL M  67     -11.617  10.127   4.169  1.00 14.47           C  
+ATOM    581  CG1 VAL M  67     -11.499  10.473   2.684  1.00 12.59           C  
+ATOM    582  CG2 VAL M  67     -10.229   9.885   4.798  1.00 14.16           C  
+ATOM    583  N   LYS M  68     -12.670  13.237   3.582  1.00 13.95           N  
+ATOM    584  CA  LYS M  68     -12.387  14.631   3.215  1.00 14.65           C  
+ATOM    585  C   LYS M  68     -12.704  15.579   4.371  1.00 13.87           C  
+ATOM    586  O   LYS M  68     -11.961  16.548   4.627  1.00 13.40           O  
+ATOM    587  CB  LYS M  68     -13.159  15.033   1.945  1.00 15.69           C  
+ATOM    588  CG  LYS M  68     -12.553  14.505   0.647  1.00 19.51           C  
+ATOM    589  CD  LYS M  68     -13.452  14.869  -0.568  1.00 23.67           C  
+ATOM    590  CE  LYS M  68     -12.680  14.861  -1.892  1.00 28.19           C  
+ATOM    591  NZ  LYS M  68     -13.575  14.883  -3.135  1.00 30.00           N  
+ATOM    592  N   ALA M  69     -13.805  15.319   5.068  1.00 13.70           N  
+ATOM    593  CA  ALA M  69     -14.176  16.143   6.235  1.00 14.28           C  
+ATOM    594  C   ALA M  69     -13.145  16.044   7.369  1.00 15.05           C  
+ATOM    595  O   ALA M  69     -12.837  17.034   8.048  1.00 13.32           O  
+ATOM    596  CB  ALA M  69     -15.567  15.767   6.754  1.00 14.06           C  
+ATOM    597  N   HIS M  70     -12.617  14.840   7.546  1.00 14.43           N  
+ATOM    598  CA  HIS M  70     -11.521  14.580   8.474  1.00 13.92           C  
+ATOM    599  C   HIS M  70     -10.270  15.394   8.048  1.00 12.17           C  
+ATOM    600  O   HIS M  70      -9.598  15.986   8.893  1.00 11.63           O  
+ATOM    601  CB  HIS M  70     -11.250  13.077   8.476  1.00 15.72           C  
+ATOM    602  CG  HIS M  70     -10.507  12.584   9.674  1.00 21.03           C  
+ATOM    603  ND1 HIS M  70     -10.856  11.427  10.334  1.00 22.27           N  
+ATOM    604  CD2 HIS M  70      -9.418  13.076  10.315  1.00 23.12           C  
+ATOM    605  CE1 HIS M  70     -10.020  11.235  11.343  1.00 25.12           C  
+ATOM    606  NE2 HIS M  70      -9.142  12.224  11.357  1.00 25.11           N  
+ATOM    607  N   SER M  71      -9.975  15.473   6.746  1.00 11.15           N  
+ATOM    608  CA  SER M  71      -8.818  16.275   6.332  1.00 11.67           C  
+ATOM    609  C   SER M  71      -8.969  17.748   6.716  1.00 10.78           C  
+ATOM    610  O   SER M  71      -7.995  18.388   7.107  1.00  9.69           O  
+ATOM    611  CB  SER M  71      -8.458  16.156   4.838  1.00 13.56           C  
+ATOM    612  OG  SER M  71      -9.425  16.784   4.004  1.00 15.50           O  
+ATOM    613  N   GLN M  72     -10.183  18.272   6.598  1.00 10.87           N  
+ATOM    614  CA  GLN M  72     -10.426  19.673   6.956  1.00 11.77           C  
+ATOM    615  C   GLN M  72     -10.316  19.844   8.484  1.00 12.03           C  
+ATOM    616  O   GLN M  72      -9.799  20.846   8.969  1.00 11.97           O  
+ATOM    617  CB  GLN M  72     -11.802  20.135   6.457  1.00 13.01           C  
+ATOM    618  CG  GLN M  72     -11.914  20.178   4.905  1.00 14.48           C  
+ATOM    619  CD  GLN M  72     -10.894  21.147   4.297  1.00 18.89           C  
+ATOM    620  OE1 GLN M  72     -10.452  22.079   4.962  1.00 16.56           O  
+ATOM    621  NE2 GLN M  72     -10.535  20.935   3.022  1.00 18.12           N  
+ATOM    622  N   THR M  73     -10.806  18.868   9.230  1.00 11.59           N  
+ATOM    623  CA  THR M  73     -10.611  18.881  10.695  1.00 12.15           C  
+ATOM    624  C   THR M  73      -9.134  19.020  11.070  1.00 12.50           C  
+ATOM    625  O   THR M  73      -8.765  19.871  11.887  1.00 12.75           O  
+ATOM    626  CB  THR M  73     -11.204  17.609  11.363  1.00 13.22           C  
+ATOM    627  OG1 THR M  73     -12.629  17.621  11.216  1.00 15.27           O  
+ATOM    628  CG2 THR M  73     -10.862  17.583  12.836  1.00 13.13           C  
+ATOM    629  N   HIS M  74      -8.278  18.192  10.464  1.00 13.49           N  
+ATOM    630  CA  HIS M  74      -6.842  18.284  10.705  1.00 12.97           C  
+ATOM    631  C   HIS M  74      -6.229  19.626  10.299  1.00 12.38           C  
+ATOM    632  O   HIS M  74      -5.308  20.106  10.935  1.00 11.46           O  
+ATOM    633  CB  HIS M  74      -6.116  17.159   9.983  1.00 13.50           C  
+ATOM    634  CG  HIS M  74      -6.094  15.863  10.741  1.00 16.33           C  
+ATOM    635  ND1 HIS M  74      -6.942  15.595  11.805  1.00 18.38           N  
+ATOM    636  CD2 HIS M  74      -5.319  14.761  10.588  1.00 15.87           C  
+ATOM    637  CE1 HIS M  74      -6.696  14.375  12.262  1.00 17.55           C  
+ATOM    638  NE2 HIS M  74      -5.719  13.847  11.541  1.00 18.55           N  
+ATOM    639  N   ARG M  75      -6.706  20.179   9.182  1.00 12.63           N  
+ATOM    640  CA  ARG M  75      -6.254  21.469   8.687  1.00 11.68           C  
+ATOM    641  C   ARG M  75      -6.552  22.529   9.756  1.00 12.32           C  
+ATOM    642  O   ARG M  75      -5.689  23.347  10.087  1.00 11.86           O  
+ATOM    643  CB  ARG M  75      -6.929  21.758   7.322  1.00 11.16           C  
+ATOM    644  CG  ARG M  75      -6.476  23.055   6.590  1.00 13.44           C  
+ATOM    645  CD  ARG M  75      -7.408  24.233   6.891  1.00 15.63           C  
+ATOM    646  NE  ARG M  75      -8.821  23.943   6.606  1.00 14.31           N  
+ATOM    647  CZ  ARG M  75      -9.825  24.630   7.154  1.00 13.69           C  
+ATOM    648  NH1 ARG M  75      -9.568  25.620   7.973  1.00 14.12           N  
+ATOM    649  NH2 ARG M  75     -11.080  24.326   6.893  1.00 16.40           N  
+ATOM    650  N   VAL M  76      -7.760  22.490  10.315  1.00 11.99           N  
+ATOM    651  CA  VAL M  76      -8.127  23.423  11.385  1.00 11.56           C  
+ATOM    652  C   VAL M  76      -7.188  23.203  12.571  1.00 12.76           C  
+ATOM    653  O   VAL M  76      -6.631  24.163  13.140  1.00 10.76           O  
+ATOM    654  CB  VAL M  76      -9.597  23.223  11.826  1.00 11.15           C  
+ATOM    655  CG1 VAL M  76      -9.913  24.077  13.074  1.00 10.34           C  
+ATOM    656  CG2 VAL M  76     -10.558  23.575  10.649  1.00  8.62           C  
+ATOM    657  N   ASP M  77      -6.976  21.930  12.905  1.00 12.16           N  
+ATOM    658  CA  ASP M  77      -6.130  21.570  14.061  1.00 12.29           C  
+ATOM    659  C   ASP M  77      -4.708  22.129  13.929  1.00 10.54           C  
+ATOM    660  O   ASP M  77      -4.147  22.655  14.890  1.00 10.33           O  
+ATOM    661  CB  ASP M  77      -6.072  20.032  14.210  1.00 12.20           C  
+ATOM    662  CG  ASP M  77      -7.368  19.437  14.724  1.00 14.85           C  
+ATOM    663  OD1 ASP M  77      -8.243  20.213  15.194  1.00 16.03           O  
+ATOM    664  OD2 ASP M  77      -7.524  18.190  14.644  1.00 13.54           O  
+ATOM    665  N   LEU M  78      -4.115  22.008  12.746  1.00 10.23           N  
+ATOM    666  CA  LEU M  78      -2.767  22.503  12.549  1.00 11.71           C  
+ATOM    667  C   LEU M  78      -2.672  24.004  12.831  1.00 11.93           C  
+ATOM    668  O   LEU M  78      -1.683  24.462  13.406  1.00 12.95           O  
+ATOM    669  CB  LEU M  78      -2.250  22.176  11.143  1.00 10.21           C  
+ATOM    670  CG  LEU M  78      -1.785  20.720  10.977  1.00 11.46           C  
+ATOM    671  CD1 LEU M  78      -1.925  20.280   9.494  1.00 12.69           C  
+ATOM    672  CD2 LEU M  78      -0.348  20.575  11.482  1.00  8.97           C  
+ATOM    673  N   GLY M  79      -3.676  24.763  12.401  1.00 11.37           N  
+ATOM    674  CA  GLY M  79      -3.708  26.191  12.705  1.00 13.52           C  
+ATOM    675  C   GLY M  79      -3.879  26.446  14.197  1.00 14.18           C  
+ATOM    676  O   GLY M  79      -3.202  27.281  14.771  1.00 16.06           O  
+ATOM    677  N   THR M  80      -4.789  25.719  14.833  1.00 13.25           N  
+ATOM    678  CA  THR M  80      -5.012  25.880  16.277  1.00 13.82           C  
+ATOM    679  C   THR M  80      -3.771  25.561  17.095  1.00 14.50           C  
+ATOM    680  O   THR M  80      -3.386  26.317  18.014  1.00 14.30           O  
+ATOM    681  CB  THR M  80      -6.183  24.993  16.730  1.00 14.83           C  
+ATOM    682  OG1 THR M  80      -7.331  25.341  15.963  1.00 15.53           O  
+ATOM    683  CG2 THR M  80      -6.488  25.171  18.208  1.00 15.49           C  
+ATOM    684  N   LEU M  81      -3.132  24.438  16.770  1.00 13.34           N  
+ATOM    685  CA  LEU M  81      -1.949  23.990  17.498  1.00 13.78           C  
+ATOM    686  C   LEU M  81      -0.747  24.937  17.329  1.00 15.76           C  
+ATOM    687  O   LEU M  81       0.028  25.142  18.269  1.00 14.46           O  
+ATOM    688  CB  LEU M  81      -1.592  22.542  17.083  1.00 11.92           C  
+ATOM    689  CG  LEU M  81      -2.660  21.526  17.560  1.00 11.81           C  
+ATOM    690  CD1 LEU M  81      -2.563  20.162  16.825  1.00  9.59           C  
+ATOM    691  CD2 LEU M  81      -2.519  21.325  19.042  1.00 11.08           C  
+ATOM    692  N   ARG M  82      -0.570  25.494  16.132  1.00 17.54           N  
+ATOM    693  CA  ARG M  82       0.473  26.519  15.932  1.00 21.48           C  
+ATOM    694  C   ARG M  82       0.313  27.636  16.973  1.00 21.09           C  
+ATOM    695  O   ARG M  82       1.288  28.094  17.571  1.00 22.66           O  
+ATOM    696  CB  ARG M  82       0.381  27.087  14.512  1.00 21.84           C  
+ATOM    697  CG  ARG M  82       1.603  27.840  14.015  1.00 26.76           C  
+ATOM    698  CD  ARG M  82       1.210  28.717  12.832  1.00 29.07           C  
+ATOM    699  NE  ARG M  82       0.105  28.109  12.098  1.00 33.23           N  
+ATOM    700  CZ  ARG M  82      -0.464  28.617  11.006  1.00 34.74           C  
+ATOM    701  NH1 ARG M  82      -0.023  29.763  10.480  1.00 36.90           N  
+ATOM    702  NH2 ARG M  82      -1.472  27.973  10.431  1.00 31.96           N  
+ATOM    703  N   GLY M  83      -0.933  28.044  17.201  1.00 21.73           N  
+ATOM    704  CA  GLY M  83      -1.286  29.037  18.209  1.00 21.59           C  
+ATOM    705  C   GLY M  83      -1.065  28.558  19.633  1.00 21.83           C  
+ATOM    706  O   GLY M  83      -0.453  29.252  20.422  1.00 20.92           O  
+ATOM    707  N   TYR M  84      -1.537  27.361  19.971  1.00 20.40           N  
+ATOM    708  CA  TYR M  84      -1.298  26.820  21.316  1.00 20.89           C  
+ATOM    709  C   TYR M  84       0.176  26.737  21.680  1.00 21.69           C  
+ATOM    710  O   TYR M  84       0.528  26.962  22.840  1.00 23.01           O  
+ATOM    711  CB  TYR M  84      -1.872  25.414  21.488  1.00 20.07           C  
+ATOM    712  CG  TYR M  84      -3.376  25.288  21.481  1.00 20.37           C  
+ATOM    713  CD1 TYR M  84      -4.205  26.408  21.580  1.00 21.21           C  
+ATOM    714  CD2 TYR M  84      -3.974  24.022  21.447  1.00 20.11           C  
+ATOM    715  CE1 TYR M  84      -5.597  26.271  21.600  1.00 20.10           C  
+ATOM    716  CE2 TYR M  84      -5.354  23.875  21.445  1.00 21.61           C  
+ATOM    717  CZ  TYR M  84      -6.157  25.007  21.532  1.00 23.42           C  
+ATOM    718  OH  TYR M  84      -7.525  24.854  21.546  1.00 26.04           O  
+ATOM    719  N   TYR M  85       1.026  26.388  20.709  1.00 21.16           N  
+ATOM    720  CA  TYR M  85       2.461  26.170  20.964  1.00 21.76           C  
+ATOM    721  C   TYR M  85       3.297  27.386  20.537  1.00 23.30           C  
+ATOM    722  O   TYR M  85       4.527  27.303  20.440  1.00 22.35           O  
+ATOM    723  CB  TYR M  85       2.973  24.878  20.299  1.00 19.97           C  
+ATOM    724  CG  TYR M  85       2.438  23.623  20.960  1.00 19.47           C  
+ATOM    725  CD1 TYR M  85       3.100  23.055  22.051  1.00 17.71           C  
+ATOM    726  CD2 TYR M  85       1.234  23.041  20.545  1.00 17.70           C  
+ATOM    727  CE1 TYR M  85       2.606  21.925  22.687  1.00 17.72           C  
+ATOM    728  CE2 TYR M  85       0.720  21.903  21.182  1.00 15.54           C  
+ATOM    729  CZ  TYR M  85       1.413  21.348  22.264  1.00 15.92           C  
+ATOM    730  OH  TYR M  85       0.947  20.223  22.941  1.00 14.34           O  
+ATOM    731  N   ASN M  86       2.611  28.495  20.260  1.00 25.55           N  
+ATOM    732  CA  ASN M  86       3.255  29.770  19.908  1.00 27.04           C  
+ATOM    733  C   ASN M  86       4.333  29.622  18.847  1.00 26.76           C  
+ATOM    734  O   ASN M  86       5.459  30.117  18.996  1.00 25.40           O  
+ATOM    735  CB  ASN M  86       3.813  30.452  21.164  1.00 29.84           C  
+ATOM    736  CG  ASN M  86       2.711  30.877  22.132  1.00 32.48           C  
+ATOM    737  OD1 ASN M  86       1.549  31.028  21.745  1.00 35.04           O  
+ATOM    738  ND2 ASN M  86       3.070  31.061  23.395  1.00 35.13           N  
+ATOM    739  N   GLN M  87       3.978  28.936  17.766  1.00 25.40           N  
+ATOM    740  CA  GLN M  87       4.939  28.639  16.724  1.00 24.55           C  
+ATOM    741  C   GLN M  87       4.680  29.582  15.566  1.00 25.95           C  
+ATOM    742  O   GLN M  87       3.581  30.113  15.417  1.00 26.61           O  
+ATOM    743  CB  GLN M  87       4.835  27.169  16.301  1.00 23.07           C  
+ATOM    744  CG  GLN M  87       5.219  26.168  17.422  1.00 20.41           C  
+ATOM    745  CD  GLN M  87       4.650  24.768  17.177  1.00 18.02           C  
+ATOM    746  OE1 GLN M  87       3.563  24.626  16.630  1.00 15.71           O  
+ATOM    747  NE2 GLN M  87       5.385  23.743  17.583  1.00 18.09           N  
+ATOM    748  N   SER M  88       5.690  29.803  14.747  1.00 26.88           N  
+ATOM    749  CA  SER M  88       5.535  30.766  13.674  1.00 28.60           C  
+ATOM    750  C   SER M  88       4.851  30.099  12.486  1.00 29.01           C  
+ATOM    751  O   SER M  88       4.749  28.859  12.421  1.00 27.66           O  
+ATOM    752  CB  SER M  88       6.878  31.388  13.300  1.00 29.12           C  
+ATOM    753  OG  SER M  88       7.565  30.616  12.345  1.00 31.30           O  
+ATOM    754  N   GLU M  89       4.359  30.918  11.563  1.00 29.61           N  
+ATOM    755  CA  GLU M  89       3.655  30.409  10.390  1.00 31.65           C  
+ATOM    756  C   GLU M  89       4.583  29.795   9.356  1.00 30.68           C  
+ATOM    757  O   GLU M  89       4.105  29.303   8.333  1.00 32.08           O  
+ATOM    758  CB  GLU M  89       2.850  31.523   9.714  1.00 33.38           C  
+ATOM    759  CG  GLU M  89       1.830  32.211  10.607  1.00 38.44           C  
+ATOM    760  CD  GLU M  89       0.769  32.943   9.792  1.00 42.39           C  
+ATOM    761  OE1 GLU M  89      -0.178  33.504  10.389  1.00 44.86           O  
+ATOM    762  OE2 GLU M  89       0.883  32.954   8.543  1.00 44.07           O  
+ATOM    763  N   ALA M  90       5.893  29.825   9.600  1.00 29.30           N  
+ATOM    764  CA  ALA M  90       6.866  29.420   8.566  1.00 28.51           C  
+ATOM    765  C   ALA M  90       7.413  27.988   8.632  1.00 26.98           C  
+ATOM    766  O   ALA M  90       8.085  27.535   7.700  1.00 27.22           O  
+ATOM    767  CB  ALA M  90       8.022  30.412   8.501  1.00 29.55           C  
+ATOM    768  N   GLY M  91       7.163  27.274   9.719  1.00 24.95           N  
+ATOM    769  CA  GLY M  91       7.662  25.900   9.807  1.00 21.72           C  
+ATOM    770  C   GLY M  91       6.565  24.903   9.458  1.00 19.74           C  
+ATOM    771  O   GLY M  91       5.388  25.232   9.517  1.00 18.64           O  
+ATOM    772  N   SER M  92       6.952  23.691   9.080  1.00 18.46           N  
+ATOM    773  CA  SER M  92       5.974  22.644   8.811  1.00 17.61           C  
+ATOM    774  C   SER M  92       5.768  21.798  10.071  1.00 16.34           C  
+ATOM    775  O   SER M  92       6.726  21.497  10.788  1.00 15.54           O  
+ATOM    776  CB  SER M  92       6.411  21.789   7.626  1.00 19.24           C  
+ATOM    777  OG  SER M  92       5.648  20.596   7.554  1.00 22.08           O  
+ATOM    778  N   HIS M  93       4.510  21.441  10.340  1.00 14.47           N  
+ATOM    779  CA  HIS M  93       4.162  20.684  11.528  1.00 13.31           C  
+ATOM    780  C   HIS M  93       3.275  19.498  11.192  1.00 11.13           C  
+ATOM    781  O   HIS M  93       2.646  19.454  10.149  1.00 10.34           O  
+ATOM    782  CB  HIS M  93       3.513  21.592  12.575  1.00 12.77           C  
+ATOM    783  CG  HIS M  93       4.434  22.673  13.048  1.00 14.87           C  
+ATOM    784  ND1 HIS M  93       5.336  22.488  14.073  1.00 13.70           N  
+ATOM    785  CD2 HIS M  93       4.631  23.933  12.591  1.00 14.19           C  
+ATOM    786  CE1 HIS M  93       6.030  23.600  14.251  1.00 16.43           C  
+ATOM    787  NE2 HIS M  93       5.629  24.487  13.358  1.00 14.87           N  
+ATOM    788  N   THR M  94       3.229  18.542  12.106  1.00 11.88           N  
+ATOM    789  CA  THR M  94       2.529  17.279  11.843  1.00  9.94           C  
+ATOM    790  C   THR M  94       1.455  16.967  12.852  1.00 10.03           C  
+ATOM    791  O   THR M  94       1.706  17.033  14.053  1.00 10.48           O  
+ATOM    792  CB  THR M  94       3.526  16.130  11.931  1.00 10.34           C  
+ATOM    793  OG1 THR M  94       4.593  16.370  11.004  1.00 10.91           O  
+ATOM    794  CG2 THR M  94       2.845  14.784  11.588  1.00 10.45           C  
+ATOM    795  N   VAL M  95       0.268  16.604  12.385  1.00  9.44           N  
+ATOM    796  CA AVAL M  95      -0.709  15.998  13.286  0.50  9.40           C  
+ATOM    797  CA BVAL M  95      -0.763  16.017  13.251  0.50  9.47           C  
+ATOM    798  C   VAL M  95      -0.929  14.540  12.885  1.00  9.26           C  
+ATOM    799  O   VAL M  95      -1.038  14.213  11.712  1.00  8.46           O  
+ATOM    800  CB AVAL M  95      -2.053  16.779  13.368  0.50 10.02           C  
+ATOM    801  CB BVAL M  95      -2.142  16.696  13.067  0.50 10.17           C  
+ATOM    802  CG1AVAL M  95      -1.853  18.157  14.023  0.50 11.24           C  
+ATOM    803  CG1BVAL M  95      -3.235  15.886  13.769  0.50 10.59           C  
+ATOM    804  CG2AVAL M  95      -2.707  16.920  12.002  0.50 10.02           C  
+ATOM    805  CG2BVAL M  95      -2.125  18.145  13.559  0.50 11.27           C  
+ATOM    806  N   GLN M  96      -0.963  13.649  13.878  1.00  9.00           N  
+ATOM    807  CA  GLN M  96      -1.288  12.239  13.608  1.00  8.67           C  
+ATOM    808  C   GLN M  96      -2.437  11.815  14.492  1.00  9.70           C  
+ATOM    809  O   GLN M  96      -2.517  12.253  15.627  1.00  9.63           O  
+ATOM    810  CB  GLN M  96      -0.081  11.327  13.876  1.00  8.21           C  
+ATOM    811  CG  GLN M  96       1.080  11.533  12.866  1.00 10.16           C  
+ATOM    812  CD  GLN M  96       2.374  11.018  13.427  1.00 11.49           C  
+ATOM    813  OE1 GLN M  96       3.105  11.771  14.078  1.00 12.30           O  
+ATOM    814  NE2 GLN M  96       2.645   9.723  13.232  1.00 10.60           N  
+ATOM    815  N   ARG M  97      -3.311  10.969  13.966  1.00  9.39           N  
+ATOM    816  CA  ARG M  97      -4.426  10.433  14.747  1.00  9.24           C  
+ATOM    817  C   ARG M  97      -4.519   8.939  14.440  1.00  9.95           C  
+ATOM    818  O   ARG M  97      -4.351   8.537  13.285  1.00  9.08           O  
+ATOM    819  CB  ARG M  97      -5.737  11.105  14.340  1.00  9.09           C  
+ATOM    820  CG  ARG M  97      -6.952  10.660  15.239  1.00 13.21           C  
+ATOM    821  CD  ARG M  97      -8.308  11.138  14.735  1.00 19.41           C  
+ATOM    822  NE  ARG M  97      -8.304  12.490  14.216  1.00 23.75           N  
+ATOM    823  CZ  ARG M  97      -8.758  13.564  14.861  1.00 24.70           C  
+ATOM    824  NH1 ARG M  97      -8.713  14.731  14.249  1.00 24.05           N  
+ATOM    825  NH2 ARG M  97      -9.249  13.489  16.100  1.00 22.98           N  
+ATOM    826  N   MET M  98      -4.807   8.123  15.447  1.00 10.09           N  
+ATOM    827  CA  MET M  98      -5.179   6.721  15.177  1.00 11.16           C  
+ATOM    828  C   MET M  98      -6.406   6.383  16.011  1.00 10.79           C  
+ATOM    829  O   MET M  98      -6.462   6.724  17.202  1.00 11.04           O  
+ATOM    830  CB  MET M  98      -4.025   5.781  15.527  1.00 11.74           C  
+ATOM    831  CG  MET M  98      -4.233   4.309  15.154  1.00 16.15           C  
+ATOM    832  SD  MET M  98      -5.120   3.391  16.432  1.00 20.25           S  
+ATOM    833  CE  MET M  98      -3.827   3.096  17.633  1.00 21.44           C  
+ATOM    834  N   TYR M  99      -7.375   5.704  15.406  1.00  9.59           N  
+ATOM    835  CA  TYR M  99      -8.486   5.174  16.182  1.00  8.88           C  
+ATOM    836  C   TYR M  99      -8.936   3.830  15.615  1.00 10.91           C  
+ATOM    837  O   TYR M  99      -8.591   3.448  14.485  1.00 10.51           O  
+ATOM    838  CB  TYR M  99      -9.649   6.161  16.297  1.00  9.20           C  
+ATOM    839  CG  TYR M  99     -10.406   6.434  15.018  1.00 11.09           C  
+ATOM    840  CD1 TYR M  99     -11.360   5.522  14.525  1.00 13.62           C  
+ATOM    841  CD2 TYR M  99     -10.214   7.602  14.331  1.00 11.20           C  
+ATOM    842  CE1 TYR M  99     -12.068   5.779  13.338  1.00 14.24           C  
+ATOM    843  CE2 TYR M  99     -10.917   7.877  13.159  1.00 14.64           C  
+ATOM    844  CZ  TYR M  99     -11.840   6.969  12.673  1.00 16.62           C  
+ATOM    845  OH  TYR M  99     -12.513   7.283  11.513  1.00 18.09           O  
+ATOM    846  N   GLY M 100      -9.688   3.092  16.422  1.00 10.22           N  
+ATOM    847  CA  GLY M 100     -10.156   1.787  15.977  1.00 11.04           C  
+ATOM    848  C   GLY M 100     -10.766   0.973  17.101  1.00 12.13           C  
+ATOM    849  O   GLY M 100     -10.858   1.439  18.227  1.00 12.01           O  
+ATOM    850  N   CYS M 101     -11.179  -0.247  16.781  1.00 11.70           N  
+ATOM    851  CA  CYS M 101     -11.877  -1.063  17.753  1.00 13.00           C  
+ATOM    852  C   CYS M 101     -11.411  -2.486  17.557  1.00 13.49           C  
+ATOM    853  O   CYS M 101     -10.953  -2.835  16.460  1.00 13.51           O  
+ATOM    854  CB  CYS M 101     -13.400  -0.980  17.550  1.00 12.37           C  
+ATOM    855  SG  CYS M 101     -13.966  -1.316  15.828  1.00 17.69           S  
+ATOM    856  N   ASP M 102     -11.524  -3.292  18.617  1.00 12.47           N  
+ATOM    857  CA  ASP M 102     -11.163  -4.713  18.551  1.00 13.89           C  
+ATOM    858  C   ASP M 102     -12.427  -5.512  18.892  1.00 14.29           C  
+ATOM    859  O   ASP M 102     -13.238  -5.071  19.724  1.00 14.24           O  
+ATOM    860  CB  ASP M 102     -10.091  -5.089  19.583  1.00 14.42           C  
+ATOM    861  CG  ASP M 102      -8.718  -4.413  19.339  1.00 18.24           C  
+ATOM    862  OD1 ASP M 102      -8.524  -3.700  18.334  1.00 15.87           O  
+ATOM    863  OD2 ASP M 102      -7.849  -4.580  20.217  1.00 19.48           O  
+ATOM    864  N   VAL M 103     -12.583  -6.674  18.266  1.00 14.08           N  
+ATOM    865  CA  VAL M 103     -13.532  -7.689  18.757  1.00 14.86           C  
+ATOM    866  C   VAL M 103     -12.742  -8.890  19.314  1.00 14.39           C  
+ATOM    867  O   VAL M 103     -11.645  -9.195  18.851  1.00 13.48           O  
+ATOM    868  CB  VAL M 103     -14.494  -8.190  17.665  1.00 14.66           C  
+ATOM    869  CG1 VAL M 103     -15.416  -7.075  17.228  1.00 16.30           C  
+ATOM    870  CG2 VAL M 103     -13.739  -8.737  16.479  1.00 13.94           C  
+ATOM    871  N   GLY M 104     -13.286  -9.555  20.325  1.00 13.18           N  
+ATOM    872  CA  GLY M 104     -12.589 -10.711  20.898  1.00 13.23           C  
+ATOM    873  C   GLY M 104     -12.933 -11.997  20.171  1.00 13.04           C  
+ATOM    874  O   GLY M 104     -13.583 -11.982  19.106  1.00 11.31           O  
+ATOM    875  N   SER M 105     -12.499 -13.119  20.747  1.00 14.01           N  
+ATOM    876  CA  SER M 105     -12.765 -14.420  20.160  1.00 13.65           C  
+ATOM    877  C   SER M 105     -14.260 -14.717  20.178  1.00 13.76           C  
+ATOM    878  O   SER M 105     -14.733 -15.590  19.441  1.00 14.39           O  
+ATOM    879  CB  SER M 105     -12.009 -15.530  20.917  1.00 15.83           C  
+ATOM    880  OG  SER M 105     -10.604 -15.292  20.936  1.00 15.85           O  
+ATOM    881  N   ASP M 106     -14.999 -13.972  20.999  1.00 14.20           N  
+ATOM    882  CA  ASP M 106     -16.462 -14.142  21.071  1.00 14.86           C  
+ATOM    883  C   ASP M 106     -17.182 -13.290  20.016  1.00 14.28           C  
+ATOM    884  O   ASP M 106     -18.409 -13.267  19.955  1.00 13.87           O  
+ATOM    885  CB  ASP M 106     -16.986 -13.827  22.483  1.00 15.04           C  
+ATOM    886  CG  ASP M 106     -16.655 -12.413  22.948  1.00 17.15           C  
+ATOM    887  OD1 ASP M 106     -17.033 -12.085  24.092  1.00 19.83           O  
+ATOM    888  OD2 ASP M 106     -16.020 -11.622  22.205  1.00 16.74           O  
+ATOM    889  N   TRP M 107     -16.392 -12.628  19.169  1.00 14.53           N  
+ATOM    890  CA  TRP M 107     -16.894 -11.707  18.123  1.00 14.56           C  
+ATOM    891  C   TRP M 107     -17.671 -10.495  18.674  1.00 14.79           C  
+ATOM    892  O   TRP M 107     -18.431  -9.853  17.936  1.00 14.79           O  
+ATOM    893  CB  TRP M 107     -17.716 -12.452  17.040  1.00 16.92           C  
+ATOM    894  CG  TRP M 107     -16.853 -13.206  16.046  1.00 19.59           C  
+ATOM    895  CD1 TRP M 107     -16.000 -14.257  16.320  1.00 21.45           C  
+ATOM    896  CD2 TRP M 107     -16.747 -12.967  14.635  1.00 20.97           C  
+ATOM    897  NE1 TRP M 107     -15.379 -14.678  15.164  1.00 22.42           N  
+ATOM    898  CE2 TRP M 107     -15.820 -13.905  14.119  1.00 22.71           C  
+ATOM    899  CE3 TRP M 107     -17.350 -12.054  13.753  1.00 22.51           C  
+ATOM    900  CZ2 TRP M 107     -15.486 -13.954  12.757  1.00 23.48           C  
+ATOM    901  CZ3 TRP M 107     -17.016 -12.102  12.405  1.00 22.03           C  
+ATOM    902  CH2 TRP M 107     -16.089 -13.040  11.922  1.00 22.52           C  
+ATOM    903  N   ARG M 108     -17.469 -10.181  19.957  1.00 13.35           N  
+ATOM    904  CA  ARG M 108     -18.108  -9.029  20.577  1.00 13.28           C  
+ATOM    905  C   ARG M 108     -17.086  -7.938  20.778  1.00 13.40           C  
+ATOM    906  O   ARG M 108     -15.907  -8.219  20.782  1.00 12.06           O  
+ATOM    907  CB  ARG M 108     -18.674  -9.381  21.951  1.00 12.83           C  
+ATOM    908  CG  ARG M 108     -19.727 -10.469  21.916  1.00 15.74           C  
+ATOM    909  CD  ARG M 108     -20.109 -10.843  23.371  1.00 16.88           C  
+ATOM    910  NE  ARG M 108     -20.730 -12.162  23.426  1.00 20.59           N  
+ATOM    911  CZ  ARG M 108     -20.835 -12.890  24.535  1.00 24.42           C  
+ATOM    912  NH1 ARG M 108     -21.437 -14.075  24.499  1.00 24.30           N  
+ATOM    913  NH2 ARG M 108     -20.342 -12.427  25.683  1.00 25.99           N  
+ATOM    914  N   PHE M 109     -17.549  -6.706  20.965  1.00 13.56           N  
+ATOM    915  CA  PHE M 109     -16.648  -5.604  21.322  1.00 15.07           C  
+ATOM    916  C   PHE M 109     -15.680  -5.980  22.450  1.00 15.60           C  
+ATOM    917  O   PHE M 109     -16.076  -6.535  23.475  1.00 16.84           O  
+ATOM    918  CB  PHE M 109     -17.460  -4.381  21.742  1.00 14.83           C  
+ATOM    919  CG  PHE M 109     -16.616  -3.237  22.223  1.00 17.89           C  
+ATOM    920  CD1 PHE M 109     -16.055  -2.338  21.316  1.00 16.56           C  
+ATOM    921  CD2 PHE M 109     -16.385  -3.056  23.574  1.00 17.55           C  
+ATOM    922  CE1 PHE M 109     -15.270  -1.295  21.757  1.00 18.31           C  
+ATOM    923  CE2 PHE M 109     -15.605  -1.999  24.027  1.00 19.75           C  
+ATOM    924  CZ  PHE M 109     -15.051  -1.124  23.132  1.00 18.23           C  
+ATOM    925  N   LEU M 110     -14.407  -5.657  22.266  1.00 15.73           N  
+ATOM    926  CA  LEU M 110     -13.391  -5.946  23.259  1.00 15.91           C  
+ATOM    927  C   LEU M 110     -12.798  -4.631  23.777  1.00 16.97           C  
+ATOM    928  O   LEU M 110     -12.757  -4.380  24.993  1.00 16.40           O  
+ATOM    929  CB  LEU M 110     -12.316  -6.793  22.598  1.00 17.19           C  
+ATOM    930  CG  LEU M 110     -11.369  -7.745  23.323  1.00 20.44           C  
+ATOM    931  CD1 LEU M 110     -10.002  -7.795  22.626  1.00 21.34           C  
+ATOM    932  CD2 LEU M 110     -11.270  -7.523  24.811  1.00 21.16           C  
+ATOM    933  N   ARG M 111     -12.361  -3.781  22.848  1.00 15.74           N  
+ATOM    934  CA  ARG M 111     -11.594  -2.570  23.186  1.00 16.51           C  
+ATOM    935  C   ARG M 111     -11.821  -1.495  22.144  1.00 14.88           C  
+ATOM    936  O   ARG M 111     -12.044  -1.807  20.977  1.00 13.59           O  
+ATOM    937  CB  ARG M 111     -10.091  -2.871  23.165  1.00 17.84           C  
+ATOM    938  CG  ARG M 111      -9.506  -3.268  24.495  1.00 24.59           C  
+ATOM    939  CD  ARG M 111      -7.981  -3.385  24.371  1.00 25.74           C  
+ATOM    940  NE  ARG M 111      -7.617  -4.274  23.280  1.00 28.11           N  
+ATOM    941  CZ  ARG M 111      -7.416  -5.580  23.410  1.00 27.50           C  
+ATOM    942  NH1 ARG M 111      -7.103  -6.303  22.350  1.00 28.44           N  
+ATOM    943  NH2 ARG M 111      -7.514  -6.166  24.602  1.00 27.84           N  
+ATOM    944  N   GLY M 112     -11.697  -0.240  22.567  1.00 14.50           N  
+ATOM    945  CA  GLY M 112     -11.704   0.916  21.658  1.00 14.62           C  
+ATOM    946  C   GLY M 112     -10.557   1.861  21.987  1.00 15.37           C  
+ATOM    947  O   GLY M 112     -10.023   1.860  23.103  1.00 15.92           O  
+ATOM    948  N   TYR M 113     -10.133   2.639  21.004  1.00 15.09           N  
+ATOM    949  CA  TYR M 113      -9.051   3.595  21.233  1.00 14.68           C  
+ATOM    950  C   TYR M 113      -9.108   4.744  20.234  1.00 14.84           C  
+ATOM    951  O   TYR M 113      -9.705   4.639  19.155  1.00 12.79           O  
+ATOM    952  CB  TYR M 113      -7.680   2.885  21.258  1.00 17.66           C  
+ATOM    953  CG  TYR M 113      -7.615   1.706  20.326  1.00 18.37           C  
+ATOM    954  CD1 TYR M 113      -7.327   1.900  18.994  1.00 21.65           C  
+ATOM    955  CD2 TYR M 113      -7.881   0.412  20.764  1.00 21.26           C  
+ATOM    956  CE1 TYR M 113      -7.280   0.853  18.104  1.00 22.36           C  
+ATOM    957  CE2 TYR M 113      -7.834  -0.673  19.874  1.00 22.41           C  
+ATOM    958  CZ  TYR M 113      -7.534  -0.436  18.537  1.00 23.01           C  
+ATOM    959  OH  TYR M 113      -7.461  -1.450  17.595  1.00 20.69           O  
+ATOM    960  N   HIS M 114      -8.538   5.872  20.642  1.00 15.14           N  
+ATOM    961  CA  HIS M 114      -8.510   7.070  19.842  1.00 15.91           C  
+ATOM    962  C   HIS M 114      -7.357   7.890  20.412  1.00 15.55           C  
+ATOM    963  O   HIS M 114      -7.481   8.437  21.520  1.00 14.79           O  
+ATOM    964  CB  HIS M 114      -9.820   7.847  19.969  1.00 17.72           C  
+ATOM    965  CG  HIS M 114      -9.826   9.132  19.193  1.00 22.31           C  
+ATOM    966  ND1 HIS M 114      -8.965  10.174  19.474  1.00 25.51           N  
+ATOM    967  CD2 HIS M 114     -10.582   9.544  18.146  1.00 24.17           C  
+ATOM    968  CE1 HIS M 114      -9.184  11.167  18.628  1.00 25.07           C  
+ATOM    969  NE2 HIS M 114     -10.164  10.812  17.815  1.00 25.50           N  
+ATOM    970  N   GLN M 115      -6.243   7.938  19.679  1.00 14.37           N  
+ATOM    971  CA AGLN M 115      -5.050   8.653  20.118  0.50 13.97           C  
+ATOM    972  CA BGLN M 115      -5.028   8.629  20.109  0.50 14.13           C  
+ATOM    973  C   GLN M 115      -4.670   9.747  19.121  1.00 12.90           C  
+ATOM    974  O   GLN M 115      -4.868   9.591  17.923  1.00 11.46           O  
+ATOM    975  CB AGLN M 115      -3.876   7.685  20.269  0.50 15.37           C  
+ATOM    976  CB BGLN M 115      -3.856   7.641  20.180  0.50 15.66           C  
+ATOM    977  CG AGLN M 115      -4.144   6.494  21.184  0.50 17.11           C  
+ATOM    978  CG BGLN M 115      -4.134   6.327  20.926  0.50 18.01           C  
+ATOM    979  CD AGLN M 115      -3.168   5.361  20.955  0.50 17.94           C  
+ATOM    980  CD BGLN M 115      -3.601   6.318  22.353  0.50 19.45           C  
+ATOM    981  OE1AGLN M 115      -2.186   5.513  20.237  0.50 19.08           O  
+ATOM    982  OE1BGLN M 115      -2.496   6.792  22.623  0.50 20.78           O  
+ATOM    983  NE2AGLN M 115      -3.436   4.216  21.561  0.50 18.83           N  
+ATOM    984  NE2BGLN M 115      -4.382   5.762  23.271  0.50 20.35           N  
+ATOM    985  N   TYR M 116      -4.101  10.842  19.634  1.00 10.97           N  
+ATOM    986  CA ATYR M 116      -3.766  12.018  18.838  0.50 10.66           C  
+ATOM    987  CA BTYR M 116      -3.755  12.015  18.829  0.50 10.91           C  
+ATOM    988  C   TYR M 116      -2.355  12.500  19.189  1.00 10.02           C  
+ATOM    989  O   TYR M 116      -2.004  12.576  20.360  1.00  8.96           O  
+ATOM    990  CB ATYR M 116      -4.786  13.114  19.167  0.50 11.54           C  
+ATOM    991  CB BTYR M 116      -4.755  13.155  19.086  0.50 12.11           C  
+ATOM    992  CG ATYR M 116      -4.806  14.340  18.285  0.50 12.53           C  
+ATOM    993  CG BTYR M 116      -4.823  14.210  17.998  0.50 13.93           C  
+ATOM    994  CD1ATYR M 116      -3.859  15.343  18.434  0.50 14.35           C  
+ATOM    995  CD1BTYR M 116      -5.839  14.192  17.050  0.50 16.03           C  
+ATOM    996  CD2ATYR M 116      -5.815  14.528  17.347  0.50 14.00           C  
+ATOM    997  CD2BTYR M 116      -3.877  15.223  17.915  0.50 16.38           C  
+ATOM    998  CE1ATYR M 116      -3.895  16.484  17.647  0.50 14.22           C  
+ATOM    999  CE1BTYR M 116      -5.915  15.146  16.052  0.50 16.43           C  
+ATOM   1000  CE2ATYR M 116      -5.863  15.664  16.552  0.50 14.63           C  
+ATOM   1001  CE2BTYR M 116      -3.942  16.188  16.910  0.50 16.74           C  
+ATOM   1002  CZ ATYR M 116      -4.892  16.641  16.706  0.50 14.63           C  
+ATOM   1003  CZ BTYR M 116      -4.963  16.140  15.981  0.50 17.48           C  
+ATOM   1004  OH ATYR M 116      -4.915  17.786  15.936  0.50 14.26           O  
+ATOM   1005  OH BTYR M 116      -5.048  17.092  14.983  0.50 19.91           O  
+ATOM   1006  N   ALA M 117      -1.551  12.817  18.174  1.00  9.48           N  
+ATOM   1007  CA  ALA M 117      -0.194  13.334  18.393  1.00  9.46           C  
+ATOM   1008  C   ALA M 117       0.053  14.641  17.644  1.00 10.73           C  
+ATOM   1009  O   ALA M 117      -0.476  14.868  16.533  1.00  9.43           O  
+ATOM   1010  CB  ALA M 117       0.848  12.286  17.958  1.00  9.56           C  
+ATOM   1011  N   TYR M 118       0.892  15.502  18.236  1.00 11.03           N  
+ATOM   1012  CA  TYR M 118       1.337  16.690  17.526  1.00  9.98           C  
+ATOM   1013  C   TYR M 118       2.856  16.737  17.500  1.00 10.37           C  
+ATOM   1014  O   TYR M 118       3.501  16.594  18.537  1.00 10.52           O  
+ATOM   1015  CB  TYR M 118       0.759  17.963  18.143  1.00  9.47           C  
+ATOM   1016  CG  TYR M 118       1.139  19.250  17.417  1.00  8.68           C  
+ATOM   1017  CD1 TYR M 118       0.827  19.434  16.072  1.00 11.41           C  
+ATOM   1018  CD2 TYR M 118       1.842  20.275  18.068  1.00 11.95           C  
+ATOM   1019  CE1 TYR M 118       1.188  20.619  15.392  1.00 11.46           C  
+ATOM   1020  CE2 TYR M 118       2.193  21.457  17.401  1.00 11.24           C  
+ATOM   1021  CZ  TYR M 118       1.865  21.614  16.061  1.00 11.72           C  
+ATOM   1022  OH  TYR M 118       2.193  22.785  15.403  1.00 11.58           O  
+ATOM   1023  N   ASP M 119       3.416  16.904  16.316  1.00  9.65           N  
+ATOM   1024  CA  ASP M 119       4.878  16.903  16.126  1.00 10.74           C  
+ATOM   1025  C   ASP M 119       5.578  15.676  16.756  1.00 12.08           C  
+ATOM   1026  O   ASP M 119       6.668  15.781  17.322  1.00 10.69           O  
+ATOM   1027  CB  ASP M 119       5.489  18.229  16.604  1.00 12.55           C  
+ATOM   1028  CG  ASP M 119       5.272  19.356  15.608  1.00 13.86           C  
+ATOM   1029  OD1 ASP M 119       4.974  19.056  14.422  1.00 12.45           O  
+ATOM   1030  OD2 ASP M 119       5.426  20.541  15.995  1.00 14.92           O  
+ATOM   1031  N   GLY M 120       4.919  14.520  16.640  1.00 10.41           N  
+ATOM   1032  CA  GLY M 120       5.533  13.261  17.015  1.00 12.76           C  
+ATOM   1033  C   GLY M 120       5.437  12.952  18.490  1.00 12.88           C  
+ATOM   1034  O   GLY M 120       6.086  12.019  18.966  1.00 13.07           O  
+ATOM   1035  N   LYS M 121       4.629  13.723  19.218  1.00 11.60           N  
+ATOM   1036  CA  LYS M 121       4.490  13.504  20.669  1.00 14.51           C  
+ATOM   1037  C   LYS M 121       3.022  13.345  21.024  1.00 12.43           C  
+ATOM   1038  O   LYS M 121       2.177  14.054  20.450  1.00 11.33           O  
+ATOM   1039  CB  LYS M 121       5.023  14.717  21.451  1.00 15.94           C  
+ATOM   1040  CG  LYS M 121       6.519  14.966  21.278  1.00 22.28           C  
+ATOM   1041  CD  LYS M 121       6.994  16.103  22.184  1.00 24.98           C  
+ATOM   1042  CE  LYS M 121       7.453  17.330  21.384  1.00 29.38           C  
+ATOM   1043  NZ  LYS M 121       6.440  17.856  20.436  1.00 32.85           N  
+ATOM   1044  N   ASP M 122       2.732  12.466  21.984  1.00 11.20           N  
+ATOM   1045  CA  ASP M 122       1.368  12.354  22.516  1.00 12.07           C  
+ATOM   1046  C   ASP M 122       0.781  13.738  22.785  1.00 11.89           C  
+ATOM   1047  O   ASP M 122       1.447  14.638  23.340  1.00 10.03           O  
+ATOM   1048  CB  ASP M 122       1.297  11.573  23.846  1.00 12.23           C  
+ATOM   1049  CG  ASP M 122       1.682  10.091  23.724  1.00 15.40           C  
+ATOM   1050  OD1 ASP M 122       2.060   9.516  24.763  1.00 13.63           O  
+ATOM   1051  OD2 ASP M 122       1.617   9.491  22.634  1.00 15.44           O  
+ATOM   1052  N   TYR M 123      -0.495  13.896  22.427  1.00 10.98           N  
+ATOM   1053  CA  TYR M 123      -1.195  15.136  22.690  1.00 11.20           C  
+ATOM   1054  C   TYR M 123      -2.407  14.813  23.578  1.00 11.28           C  
+ATOM   1055  O   TYR M 123      -2.449  15.165  24.771  1.00 11.54           O  
+ATOM   1056  CB  TYR M 123      -1.576  15.830  21.364  1.00 11.24           C  
+ATOM   1057  CG  TYR M 123      -2.299  17.139  21.585  1.00  7.91           C  
+ATOM   1058  CD1 TYR M 123      -1.602  18.270  22.029  1.00 10.79           C  
+ATOM   1059  CD2 TYR M 123      -3.675  17.237  21.402  1.00  8.79           C  
+ATOM   1060  CE1 TYR M 123      -2.260  19.482  22.254  1.00 10.46           C  
+ATOM   1061  CE2 TYR M 123      -4.350  18.451  21.630  1.00  8.25           C  
+ATOM   1062  CZ  TYR M 123      -3.634  19.556  22.062  1.00  8.09           C  
+ATOM   1063  OH  TYR M 123      -4.298  20.739  22.304  1.00  8.64           O  
+ATOM   1064  N   ILE M 124      -3.353  14.053  23.034  1.00 10.29           N  
+ATOM   1065  CA  ILE M 124      -4.525  13.651  23.812  1.00 10.27           C  
+ATOM   1066  C   ILE M 124      -4.969  12.249  23.401  1.00 12.36           C  
+ATOM   1067  O   ILE M 124      -4.840  11.868  22.239  1.00 12.46           O  
+ATOM   1068  CB  ILE M 124      -5.686  14.698  23.684  1.00 11.07           C  
+ATOM   1069  CG1 ILE M 124      -6.674  14.567  24.839  1.00 11.87           C  
+ATOM   1070  CG2 ILE M 124      -6.373  14.619  22.269  1.00  8.60           C  
+ATOM   1071  CD1 ILE M 124      -7.805  15.636  24.831  1.00 12.92           C  
+ATOM   1072  N   ALA M 125      -5.462  11.472  24.362  1.00 12.31           N  
+ATOM   1073  CA  ALA M 125      -5.983  10.153  24.044  1.00 13.44           C  
+ATOM   1074  C   ALA M 125      -7.240   9.831  24.855  1.00 13.68           C  
+ATOM   1075  O   ALA M 125      -7.393  10.269  26.004  1.00 13.59           O  
+ATOM   1076  CB  ALA M 125      -4.910   9.110  24.251  1.00 12.43           C  
+ATOM   1077  N   LEU M 126      -8.142   9.066  24.249  1.00 13.63           N  
+ATOM   1078  CA  LEU M 126      -9.298   8.518  24.954  1.00 14.35           C  
+ATOM   1079  C   LEU M 126      -8.828   7.388  25.871  1.00 16.42           C  
+ATOM   1080  O   LEU M 126      -8.073   6.520  25.431  1.00 16.10           O  
+ATOM   1081  CB  LEU M 126     -10.289   7.954  23.926  1.00 15.65           C  
+ATOM   1082  CG  LEU M 126     -11.668   7.556  24.424  1.00 16.85           C  
+ATOM   1083  CD1 LEU M 126     -12.422   8.782  24.947  1.00 17.46           C  
+ATOM   1084  CD2 LEU M 126     -12.423   6.887  23.263  1.00 16.36           C  
+ATOM   1085  N   LYS M 127      -9.269   7.394  27.129  1.00 17.06           N  
+ATOM   1086  CA ALYS M 127      -8.889   6.346  28.082  0.50 18.51           C  
+ATOM   1087  CA BLYS M 127      -8.888   6.347  28.080  0.50 18.62           C  
+ATOM   1088  C   LYS M 127      -9.608   5.034  27.770  1.00 19.43           C  
+ATOM   1089  O   LYS M 127     -10.602   5.027  27.056  1.00 18.17           O  
+ATOM   1090  CB ALYS M 127      -9.174   6.787  29.525  0.50 18.38           C  
+ATOM   1091  CB BLYS M 127      -9.160   6.799  29.522  0.50 18.63           C  
+ATOM   1092  CG ALYS M 127      -8.553   8.133  29.878  0.50 18.98           C  
+ATOM   1093  CG BLYS M 127      -8.283   7.971  29.955  0.50 19.58           C  
+ATOM   1094  CD ALYS M 127      -8.561   8.388  31.372  0.50 20.24           C  
+ATOM   1095  CD BLYS M 127      -8.594   8.426  31.374  0.50 21.09           C  
+ATOM   1096  CE ALYS M 127      -7.418   7.669  32.073  0.50 19.14           C  
+ATOM   1097  CE BLYS M 127      -7.539   9.402  31.886  0.50 20.74           C  
+ATOM   1098  NZ ALYS M 127      -7.152   8.319  33.397  0.50 20.59           N  
+ATOM   1099  NZ BLYS M 127      -7.922  10.001  33.186  0.50 21.38           N  
+ATOM   1100  N   GLU M 128      -9.089   3.927  28.303  1.00 21.81           N  
+ATOM   1101  CA  GLU M 128      -9.666   2.598  28.027  1.00 23.76           C  
+ATOM   1102  C   GLU M 128     -11.173   2.499  28.304  1.00 22.95           C  
+ATOM   1103  O   GLU M 128     -11.883   1.804  27.586  1.00 21.93           O  
+ATOM   1104  CB  GLU M 128      -8.903   1.491  28.774  1.00 26.11           C  
+ATOM   1105  CG  GLU M 128      -7.436   1.328  28.367  1.00 32.32           C  
+ATOM   1106  CD  GLU M 128      -6.628   0.502  29.378  1.00 37.06           C  
+ATOM   1107  OE1 GLU M 128      -7.183   0.159  30.457  1.00 38.45           O  
+ATOM   1108  OE2 GLU M 128      -5.437   0.199  29.098  1.00 37.94           O  
+ATOM   1109  N   ASP M 129     -11.669   3.185  29.330  1.00 22.96           N  
+ATOM   1110  CA  ASP M 129     -13.124   3.183  29.608  1.00 23.62           C  
+ATOM   1111  C   ASP M 129     -13.989   3.918  28.576  1.00 22.50           C  
+ATOM   1112  O   ASP M 129     -15.213   3.898  28.664  1.00 22.68           O  
+ATOM   1113  CB  ASP M 129     -13.434   3.695  31.023  1.00 26.23           C  
+ATOM   1114  CG  ASP M 129     -13.161   5.190  31.211  1.00 30.13           C  
+ATOM   1115  OD1 ASP M 129     -12.798   5.929  30.258  1.00 32.15           O  
+ATOM   1116  OD2 ASP M 129     -13.324   5.643  32.363  1.00 33.18           O  
+ATOM   1117  N   LEU M 130     -13.348   4.569  27.604  1.00 20.54           N  
+ATOM   1118  CA  LEU M 130     -14.056   5.296  26.550  1.00 19.13           C  
+ATOM   1119  C   LEU M 130     -14.937   6.419  27.113  1.00 19.30           C  
+ATOM   1120  O   LEU M 130     -15.896   6.852  26.478  1.00 18.98           O  
+ATOM   1121  CB  LEU M 130     -14.869   4.334  25.646  1.00 18.99           C  
+ATOM   1122  CG  LEU M 130     -14.058   3.143  25.091  1.00 17.16           C  
+ATOM   1123  CD1 LEU M 130     -14.813   2.351  24.040  1.00 19.29           C  
+ATOM   1124  CD2 LEU M 130     -12.767   3.646  24.503  1.00 16.83           C  
+ATOM   1125  N   ARG M 131     -14.588   6.917  28.296  1.00 20.04           N  
+ATOM   1126  CA  ARG M 131     -15.402   7.967  28.914  1.00 21.91           C  
+ATOM   1127  C   ARG M 131     -14.620   9.241  29.250  1.00 22.12           C  
+ATOM   1128  O   ARG M 131     -15.220  10.274  29.559  1.00 22.39           O  
+ATOM   1129  CB  ARG M 131     -16.078   7.459  30.189  1.00 23.81           C  
+ATOM   1130  CG  ARG M 131     -16.977   6.267  29.986  1.00 28.51           C  
+ATOM   1131  CD  ARG M 131     -17.729   5.915  31.256  1.00 32.99           C  
+ATOM   1132  NE  ARG M 131     -18.479   4.668  31.099  1.00 38.27           N  
+ATOM   1133  CZ  ARG M 131     -19.786   4.592  30.859  1.00 39.85           C  
+ATOM   1134  NH1 ARG M 131     -20.517   5.700  30.756  1.00 41.42           N  
+ATOM   1135  NH2 ARG M 131     -20.364   3.401  30.731  1.00 41.14           N  
+ATOM   1136  N   SER M 132     -13.297   9.170  29.226  1.00 19.76           N  
+ATOM   1137  CA  SER M 132     -12.519  10.333  29.629  1.00 19.45           C  
+ATOM   1138  C   SER M 132     -11.220  10.384  28.861  1.00 18.04           C  
+ATOM   1139  O   SER M 132     -10.901   9.453  28.108  1.00 16.16           O  
+ATOM   1140  CB  SER M 132     -12.241  10.308  31.133  1.00 19.31           C  
+ATOM   1141  OG  SER M 132     -11.670   9.062  31.492  1.00 23.77           O  
+ATOM   1142  N   TRP M 133     -10.458  11.450  29.091  1.00 16.27           N  
+ATOM   1143  CA  TRP M 133      -9.293  11.738  28.266  1.00 16.44           C  
+ATOM   1144  C   TRP M 133      -7.994  11.867  29.044  1.00 17.69           C  
+ATOM   1145  O   TRP M 133      -7.994  12.275  30.219  1.00 17.81           O  
+ATOM   1146  CB  TRP M 133      -9.530  13.035  27.519  1.00 15.50           C  
+ATOM   1147  CG  TRP M 133     -10.760  13.036  26.665  1.00 15.79           C  
+ATOM   1148  CD1 TRP M 133     -12.013  13.457  27.015  1.00 16.55           C  
+ATOM   1149  CD2 TRP M 133     -10.848  12.600  25.299  1.00 15.33           C  
+ATOM   1150  NE1 TRP M 133     -12.878  13.314  25.941  1.00 17.42           N  
+ATOM   1151  CE2 TRP M 133     -12.180  12.793  24.880  1.00 15.22           C  
+ATOM   1152  CE3 TRP M 133      -9.921  12.077  24.387  1.00 16.00           C  
+ATOM   1153  CZ2 TRP M 133     -12.614  12.461  23.591  1.00 14.52           C  
+ATOM   1154  CZ3 TRP M 133     -10.358  11.758  23.095  1.00 14.49           C  
+ATOM   1155  CH2 TRP M 133     -11.679  11.949  22.721  1.00 12.81           C  
+ATOM   1156  N   THR M 134      -6.887  11.530  28.385  1.00 15.77           N  
+ATOM   1157  CA  THR M 134      -5.571  11.785  28.932  1.00 16.81           C  
+ATOM   1158  C   THR M 134      -4.920  12.901  28.124  1.00 15.82           C  
+ATOM   1159  O   THR M 134      -4.652  12.707  26.936  1.00 14.08           O  
+ATOM   1160  CB  THR M 134      -4.642  10.564  28.805  1.00 17.85           C  
+ATOM   1161  OG1 THR M 134      -5.183   9.467  29.520  1.00 21.53           O  
+ATOM   1162  CG2 THR M 134      -3.265  10.883  29.362  1.00 20.62           C  
+ATOM   1163  N   ALA M 135      -4.677  14.051  28.755  1.00 14.09           N  
+ATOM   1164  CA  ALA M 135      -3.950  15.165  28.121  1.00 12.78           C  
+ATOM   1165  C   ALA M 135      -2.494  15.106  28.520  1.00 12.68           C  
+ATOM   1166  O   ALA M 135      -2.182  15.038  29.703  1.00 11.78           O  
+ATOM   1167  CB  ALA M 135      -4.543  16.517  28.543  1.00 11.89           C  
+ATOM   1168  N   ALA M 136      -1.585  15.122  27.552  1.00 12.00           N  
+ATOM   1169  CA  ALA M 136      -0.159  15.011  27.883  1.00 12.99           C  
+ATOM   1170  C   ALA M 136       0.472  16.316  28.419  1.00 13.27           C  
+ATOM   1171  O   ALA M 136       1.468  16.264  29.125  1.00 13.73           O  
+ATOM   1172  CB  ALA M 136       0.638  14.525  26.658  1.00 12.85           C  
+ATOM   1173  N   ASP M 137      -0.080  17.472  28.048  1.00 11.91           N  
+ATOM   1174  CA  ASP M 137       0.467  18.769  28.480  1.00 12.71           C  
+ATOM   1175  C   ASP M 137      -0.652  19.787  28.680  1.00 12.38           C  
+ATOM   1176  O   ASP M 137      -1.849  19.450  28.535  1.00 10.73           O  
+ATOM   1177  CB  ASP M 137       1.570  19.314  27.519  1.00 12.41           C  
+ATOM   1178  CG  ASP M 137       1.056  19.602  26.097  1.00 16.33           C  
+ATOM   1179  OD1 ASP M 137      -0.184  19.747  25.905  1.00 15.25           O  
+ATOM   1180  OD2 ASP M 137       1.900  19.705  25.163  1.00 15.85           O  
+ATOM   1181  N   MET M 138      -0.277  21.019  29.016  1.00 12.38           N  
+ATOM   1182  CA  MET M 138      -1.282  22.044  29.321  1.00 13.36           C  
+ATOM   1183  C   MET M 138      -2.070  22.467  28.080  1.00 13.08           C  
+ATOM   1184  O   MET M 138      -3.263  22.735  28.162  1.00 15.00           O  
+ATOM   1185  CB  MET M 138      -0.645  23.256  30.021  1.00 14.27           C  
+ATOM   1186  CG  MET M 138      -0.051  22.934  31.395  1.00 16.87           C  
+ATOM   1187  SD  MET M 138      -1.085  21.925  32.497  1.00 16.89           S  
+ATOM   1188  CE  MET M 138      -2.456  23.020  32.885  1.00 17.35           C  
+ATOM   1189  N   ALA M 139      -1.429  22.512  26.919  1.00 12.49           N  
+ATOM   1190  CA  ALA M 139      -2.190  22.777  25.689  1.00 13.67           C  
+ATOM   1191  C   ALA M 139      -3.342  21.764  25.542  1.00 13.36           C  
+ATOM   1192  O   ALA M 139      -4.487  22.134  25.314  1.00 13.96           O  
+ATOM   1193  CB  ALA M 139      -1.270  22.705  24.474  1.00 15.33           C  
+ATOM   1194  N   ALA M 140      -3.020  20.487  25.669  1.00 11.40           N  
+ATOM   1195  CA  ALA M 140      -4.036  19.429  25.576  1.00 11.84           C  
+ATOM   1196  C   ALA M 140      -5.142  19.537  26.645  1.00 12.99           C  
+ATOM   1197  O   ALA M 140      -6.253  19.038  26.443  1.00 11.62           O  
+ATOM   1198  CB  ALA M 140      -3.376  18.068  25.622  1.00  9.98           C  
+ATOM   1199  N   GLN M 141      -4.865  20.170  27.788  1.00 14.58           N  
+ATOM   1200  CA  GLN M 141      -5.957  20.409  28.753  1.00 15.36           C  
+ATOM   1201  C   GLN M 141      -7.082  21.252  28.149  1.00 15.45           C  
+ATOM   1202  O   GLN M 141      -8.255  21.058  28.453  1.00 14.61           O  
+ATOM   1203  CB  GLN M 141      -5.465  21.112  30.017  1.00 15.91           C  
+ATOM   1204  CG  GLN M 141      -4.530  20.309  30.872  1.00 17.75           C  
+ATOM   1205  CD  GLN M 141      -5.240  19.242  31.675  1.00 19.66           C  
+ATOM   1206  OE1 GLN M 141      -5.310  19.317  32.919  1.00 22.21           O  
+ATOM   1207  NE2 GLN M 141      -5.767  18.245  30.987  1.00 17.01           N  
+ATOM   1208  N   THR M 142      -6.713  22.213  27.313  1.00 15.06           N  
+ATOM   1209  CA  THR M 142      -7.686  23.018  26.584  1.00 15.97           C  
+ATOM   1210  C   THR M 142      -8.588  22.121  25.717  1.00 14.88           C  
+ATOM   1211  O   THR M 142      -9.816  22.180  25.793  1.00 14.59           O  
+ATOM   1212  CB  THR M 142      -6.941  24.069  25.720  1.00 17.08           C  
+ATOM   1213  OG1 THR M 142      -6.201  24.938  26.599  1.00 17.93           O  
+ATOM   1214  CG2 THR M 142      -7.894  24.896  24.910  1.00 20.03           C  
+ATOM   1215  N   THR M 143      -7.969  21.263  24.917  1.00 13.42           N  
+ATOM   1216  CA  THR M 143      -8.733  20.334  24.077  1.00 12.61           C  
+ATOM   1217  C   THR M 143      -9.609  19.398  24.935  1.00 12.52           C  
+ATOM   1218  O   THR M 143     -10.791  19.172  24.635  1.00 13.30           O  
+ATOM   1219  CB  THR M 143      -7.779  19.525  23.183  1.00 12.51           C  
+ATOM   1220  OG1 THR M 143      -7.051  20.431  22.344  1.00 12.97           O  
+ATOM   1221  CG2 THR M 143      -8.540  18.495  22.325  1.00  9.69           C  
+ATOM   1222  N   LYS M 144      -9.039  18.854  26.006  1.00 12.86           N  
+ATOM   1223  CA  LYS M 144      -9.794  17.962  26.889  1.00 13.45           C  
+ATOM   1224  C   LYS M 144     -11.061  18.648  27.418  1.00 13.82           C  
+ATOM   1225  O   LYS M 144     -12.134  18.021  27.509  1.00 11.88           O  
+ATOM   1226  CB  LYS M 144      -8.920  17.499  28.066  1.00 13.60           C  
+ATOM   1227  CG  LYS M 144      -9.648  16.709  29.141  1.00 14.85           C  
+ATOM   1228  CD  LYS M 144      -8.681  16.222  30.234  1.00 17.53           C  
+ATOM   1229  CE  LYS M 144      -9.414  15.340  31.234  1.00 20.96           C  
+ATOM   1230  NZ  LYS M 144      -8.500  14.608  32.158  1.00 23.39           N  
+ATOM   1231  N   HIS M 145     -10.936  19.914  27.814  1.00 14.51           N  
+ATOM   1232  CA  HIS M 145     -12.095  20.633  28.350  1.00 16.62           C  
+ATOM   1233  C   HIS M 145     -13.132  20.860  27.257  1.00 16.63           C  
+ATOM   1234  O   HIS M 145     -14.328  20.650  27.469  1.00 16.32           O  
+ATOM   1235  CB  HIS M 145     -11.695  21.979  28.959  1.00 18.52           C  
+ATOM   1236  CG  HIS M 145     -12.863  22.874  29.205  1.00 23.12           C  
+ATOM   1237  ND1 HIS M 145     -13.747  22.668  30.241  1.00 23.70           N  
+ATOM   1238  CD2 HIS M 145     -13.326  23.947  28.522  1.00 26.18           C  
+ATOM   1239  CE1 HIS M 145     -14.692  23.591  30.202  1.00 25.69           C  
+ATOM   1240  NE2 HIS M 145     -14.459  24.380  29.168  1.00 26.94           N  
+ATOM   1241  N   LYS M 146     -12.661  21.260  26.078  1.00 15.52           N  
+ATOM   1242  CA ALYS M 146     -13.546  21.535  24.957  0.50 16.23           C  
+ATOM   1243  CA BLYS M 146     -13.528  21.531  24.941  0.50 16.42           C  
+ATOM   1244  C   LYS M 146     -14.310  20.261  24.574  1.00 16.51           C  
+ATOM   1245  O   LYS M 146     -15.537  20.288  24.334  1.00 16.95           O  
+ATOM   1246  CB ALYS M 146     -12.734  22.065  23.780  0.50 16.75           C  
+ATOM   1247  CB BLYS M 146     -12.667  21.989  23.770  0.50 17.18           C  
+ATOM   1248  CG ALYS M 146     -13.479  22.192  22.469  0.50 17.10           C  
+ATOM   1249  CG BLYS M 146     -13.407  22.541  22.576  0.50 18.18           C  
+ATOM   1250  CD ALYS M 146     -12.500  22.588  21.379  0.50 18.48           C  
+ATOM   1251  CD BLYS M 146     -12.408  23.238  21.655  0.50 19.76           C  
+ATOM   1252  CE ALYS M 146     -13.173  22.710  20.020  0.50 19.07           C  
+ATOM   1253  CE BLYS M 146     -13.037  23.562  20.322  0.50 21.12           C  
+ATOM   1254  NZ ALYS M 146     -12.299  23.440  19.050  0.50 18.17           N  
+ATOM   1255  NZ BLYS M 146     -13.575  22.324  19.683  0.50 21.14           N  
+ATOM   1256  N   TRP M 147     -13.602  19.140  24.559  1.00 15.22           N  
+ATOM   1257  CA  TRP M 147     -14.202  17.869  24.167  1.00 14.21           C  
+ATOM   1258  C   TRP M 147     -15.121  17.298  25.237  1.00 15.92           C  
+ATOM   1259  O   TRP M 147     -16.110  16.652  24.909  1.00 15.67           O  
+ATOM   1260  CB  TRP M 147     -13.095  16.872  23.760  1.00 13.36           C  
+ATOM   1261  CG  TRP M 147     -12.509  17.217  22.435  1.00 13.02           C  
+ATOM   1262  CD1 TRP M 147     -12.789  18.314  21.676  1.00 13.95           C  
+ATOM   1263  CD2 TRP M 147     -11.498  16.486  21.730  1.00 12.82           C  
+ATOM   1264  NE1 TRP M 147     -12.032  18.299  20.518  1.00 15.31           N  
+ATOM   1265  CE2 TRP M 147     -11.237  17.181  20.526  1.00 13.22           C  
+ATOM   1266  CE3 TRP M 147     -10.812  15.296  21.988  1.00 11.79           C  
+ATOM   1267  CZ2 TRP M 147     -10.294  16.740  19.593  1.00 13.90           C  
+ATOM   1268  CZ3 TRP M 147      -9.856  14.854  21.054  1.00 12.68           C  
+ATOM   1269  CH2 TRP M 147      -9.640  15.560  19.857  1.00 12.32           C  
+ATOM   1270  N   GLU M 148     -14.792  17.512  26.517  1.00 16.04           N  
+ATOM   1271  CA  GLU M 148     -15.683  17.114  27.616  1.00 17.80           C  
+ATOM   1272  C   GLU M 148     -17.008  17.868  27.543  1.00 19.13           C  
+ATOM   1273  O   GLU M 148     -18.103  17.283  27.697  1.00 19.07           O  
+ATOM   1274  CB  GLU M 148     -15.026  17.384  28.986  1.00 18.52           C  
+ATOM   1275  CG  GLU M 148     -13.903  16.423  29.325  1.00 20.89           C  
+ATOM   1276  CD  GLU M 148     -13.213  16.781  30.638  1.00 24.57           C  
+ATOM   1277  OE1 GLU M 148     -12.512  15.924  31.198  1.00 26.13           O  
+ATOM   1278  OE2 GLU M 148     -13.373  17.927  31.106  1.00 27.14           O  
+ATOM   1279  N   ALA M 149     -16.902  19.171  27.329  1.00 17.94           N  
+ATOM   1280  CA  ALA M 149     -18.076  20.037  27.237  1.00 20.33           C  
+ATOM   1281  C   ALA M 149     -19.005  19.661  26.071  1.00 21.62           C  
+ATOM   1282  O   ALA M 149     -20.232  19.814  26.165  1.00 22.21           O  
+ATOM   1283  CB  ALA M 149     -17.645  21.487  27.123  1.00 19.52           C  
+ATOM   1284  N   ALA M 150     -18.418  19.192  24.974  1.00 21.27           N  
+ATOM   1285  CA  ALA M 150     -19.184  18.841  23.778  1.00 22.27           C  
+ATOM   1286  C   ALA M 150     -19.497  17.338  23.700  1.00 22.27           C  
+ATOM   1287  O   ALA M 150     -19.975  16.848  22.663  1.00 22.57           O  
+ATOM   1288  CB  ALA M 150     -18.448  19.287  22.545  1.00 21.57           C  
+ATOM   1289  N   HIS M 151     -19.203  16.618  24.781  1.00 21.10           N  
+ATOM   1290  CA  HIS M 151     -19.457  15.178  24.885  1.00 22.53           C  
+ATOM   1291  C   HIS M 151     -18.907  14.356  23.718  1.00 21.93           C  
+ATOM   1292  O   HIS M 151     -19.554  13.423  23.241  1.00 21.57           O  
+ATOM   1293  CB  HIS M 151     -20.945  14.891  25.128  1.00 24.99           C  
+ATOM   1294  CG  HIS M 151     -21.489  15.599  26.329  1.00 28.57           C  
+ATOM   1295  ND1 HIS M 151     -21.352  15.104  27.610  1.00 31.30           N  
+ATOM   1296  CD2 HIS M 151     -22.125  16.786  26.451  1.00 30.05           C  
+ATOM   1297  CE1 HIS M 151     -21.905  15.945  28.466  1.00 31.07           C  
+ATOM   1298  NE2 HIS M 151     -22.374  16.977  27.789  1.00 30.72           N  
+ATOM   1299  N   VAL M 152     -17.698  14.701  23.284  1.00 19.39           N  
+ATOM   1300  CA  VAL M 152     -17.043  13.954  22.231  1.00 18.21           C  
+ATOM   1301  C   VAL M 152     -16.829  12.487  22.607  1.00 17.52           C  
+ATOM   1302  O   VAL M 152     -17.045  11.595  21.786  1.00 17.38           O  
+ATOM   1303  CB  VAL M 152     -15.701  14.589  21.846  1.00 18.06           C  
+ATOM   1304  CG1 VAL M 152     -15.031  13.774  20.737  1.00 16.29           C  
+ATOM   1305  CG2 VAL M 152     -15.928  16.028  21.392  1.00 16.21           C  
+ATOM   1306  N   ALA M 153     -16.406  12.224  23.840  1.00 17.21           N  
+ATOM   1307  CA  ALA M 153     -16.187  10.844  24.264  1.00 18.59           C  
+ATOM   1308  C   ALA M 153     -17.431   9.955  24.075  1.00 20.00           C  
+ATOM   1309  O   ALA M 153     -17.319   8.800  23.652  1.00 17.96           O  
+ATOM   1310  CB  ALA M 153     -15.704  10.792  25.725  1.00 18.60           C  
+ATOM   1311  N   GLU M 154     -18.613  10.488  24.397  1.00 20.53           N  
+ATOM   1312  CA  GLU M 154     -19.848   9.703  24.257  1.00 23.63           C  
+ATOM   1313  C   GLU M 154     -20.128   9.361  22.808  1.00 22.75           C  
+ATOM   1314  O   GLU M 154     -20.558   8.250  22.489  1.00 22.03           O  
+ATOM   1315  CB  GLU M 154     -21.050  10.469  24.786  1.00 25.50           C  
+ATOM   1316  CG  GLU M 154     -21.370  10.250  26.247  1.00 33.16           C  
+ATOM   1317  CD  GLU M 154     -22.737  10.840  26.597  1.00 37.49           C  
+ATOM   1318  OE1 GLU M 154     -23.545  11.053  25.655  1.00 39.88           O  
+ATOM   1319  OE2 GLU M 154     -22.999  11.101  27.796  1.00 39.81           O  
+ATOM   1320  N   GLN M 155     -19.926  10.338  21.935  1.00 22.33           N  
+ATOM   1321  CA  GLN M 155     -20.122  10.119  20.514  1.00 23.36           C  
+ATOM   1322  C   GLN M 155     -19.185   9.012  20.016  1.00 21.74           C  
+ATOM   1323  O   GLN M 155     -19.610   8.080  19.315  1.00 20.88           O  
+ATOM   1324  CB  GLN M 155     -19.936  11.433  19.754  1.00 25.57           C  
+ATOM   1325  CG  GLN M 155     -21.062  12.433  20.034  1.00 31.70           C  
+ATOM   1326  CD  GLN M 155     -20.626  13.888  19.888  1.00 35.50           C  
+ATOM   1327  OE1 GLN M 155     -20.087  14.288  18.851  1.00 38.78           O  
+ATOM   1328  NE2 GLN M 155     -20.850  14.685  20.939  1.00 36.39           N  
+ATOM   1329  N   LEU M 156     -17.922   9.101  20.419  1.00 19.63           N  
+ATOM   1330  CA  LEU M 156     -16.907   8.160  19.960  1.00 18.32           C  
+ATOM   1331  C   LEU M 156     -17.178   6.782  20.545  1.00 17.68           C  
+ATOM   1332  O   LEU M 156     -16.998   5.774  19.878  1.00 16.27           O  
+ATOM   1333  CB  LEU M 156     -15.505   8.626  20.383  1.00 18.07           C  
+ATOM   1334  CG  LEU M 156     -14.845   9.800  19.651  1.00 20.45           C  
+ATOM   1335  CD1 LEU M 156     -13.391  10.023  20.155  1.00 19.66           C  
+ATOM   1336  CD2 LEU M 156     -14.850   9.536  18.158  1.00 20.44           C  
+ATOM   1337  N   ARG M 157     -17.615   6.749  21.803  1.00 17.68           N  
+ATOM   1338  CA  ARG M 157     -17.938   5.491  22.453  1.00 18.94           C  
+ATOM   1339  C   ARG M 157     -19.068   4.763  21.707  1.00 17.63           C  
+ATOM   1340  O   ARG M 157     -18.986   3.560  21.467  1.00 17.96           O  
+ATOM   1341  CB  ARG M 157     -18.320   5.711  23.918  1.00 20.30           C  
+ATOM   1342  CG  ARG M 157     -18.634   4.416  24.653  1.00 25.16           C  
+ATOM   1343  CD  ARG M 157     -18.896   4.673  26.120  1.00 30.18           C  
+ATOM   1344  NE  ARG M 157     -19.032   3.420  26.855  1.00 36.95           N  
+ATOM   1345  CZ  ARG M 157     -20.095   3.082  27.587  1.00 40.23           C  
+ATOM   1346  NH1 ARG M 157     -21.127   3.918  27.703  1.00 41.12           N  
+ATOM   1347  NH2 ARG M 157     -20.119   1.912  28.220  1.00 41.15           N  
+ATOM   1348  N   ALA M 158     -20.106   5.497  21.321  1.00 17.56           N  
+ATOM   1349  CA  ALA M 158     -21.220   4.888  20.585  1.00 17.85           C  
+ATOM   1350  C   ALA M 158     -20.739   4.283  19.264  1.00 17.43           C  
+ATOM   1351  O   ALA M 158     -21.191   3.194  18.864  1.00 15.90           O  
+ATOM   1352  CB  ALA M 158     -22.336   5.891  20.335  1.00 15.85           C  
+ATOM   1353  N   TYR M 159     -19.820   4.986  18.601  1.00 15.30           N  
+ATOM   1354  CA  TYR M 159     -19.244   4.490  17.349  1.00 15.05           C  
+ATOM   1355  C   TYR M 159     -18.404   3.244  17.604  1.00 13.90           C  
+ATOM   1356  O   TYR M 159     -18.566   2.219  16.928  1.00 14.28           O  
+ATOM   1357  CB  TYR M 159     -18.420   5.581  16.630  1.00 15.01           C  
+ATOM   1358  CG  TYR M 159     -17.443   5.034  15.588  1.00 15.21           C  
+ATOM   1359  CD1 TYR M 159     -17.851   4.778  14.267  1.00 15.72           C  
+ATOM   1360  CD2 TYR M 159     -16.111   4.803  15.920  1.00 15.78           C  
+ATOM   1361  CE1 TYR M 159     -16.949   4.280  13.310  1.00 14.49           C  
+ATOM   1362  CE2 TYR M 159     -15.193   4.304  14.977  1.00 12.16           C  
+ATOM   1363  CZ  TYR M 159     -15.623   4.042  13.678  1.00 13.92           C  
+ATOM   1364  OH  TYR M 159     -14.719   3.549  12.747  1.00 12.92           O  
+ATOM   1365  N   LEU M 160     -17.515   3.321  18.592  1.00 12.70           N  
+ATOM   1366  CA  LEU M 160     -16.552   2.247  18.851  1.00 14.74           C  
+ATOM   1367  C   LEU M 160     -17.239   0.931  19.258  1.00 16.59           C  
+ATOM   1368  O   LEU M 160     -16.782  -0.160  18.910  1.00 16.78           O  
+ATOM   1369  CB  LEU M 160     -15.561   2.694  19.937  1.00 13.35           C  
+ATOM   1370  CG  LEU M 160     -14.593   3.814  19.513  1.00 15.31           C  
+ATOM   1371  CD1 LEU M 160     -13.743   4.267  20.698  1.00 15.92           C  
+ATOM   1372  CD2 LEU M 160     -13.686   3.360  18.379  1.00 13.71           C  
+ATOM   1373  N   GLU M 161     -18.340   1.049  19.995  1.00 17.07           N  
+ATOM   1374  CA  GLU M 161     -19.030  -0.127  20.532  1.00 18.56           C  
+ATOM   1375  C   GLU M 161     -20.136  -0.560  19.597  1.00 18.65           C  
+ATOM   1376  O   GLU M 161     -20.746  -1.615  19.787  1.00 18.92           O  
+ATOM   1377  CB  GLU M 161     -19.631   0.205  21.905  1.00 19.53           C  
+ATOM   1378  CG  GLU M 161     -18.618   0.315  23.016  1.00 23.34           C  
+ATOM   1379  CD  GLU M 161     -19.251   0.704  24.347  1.00 27.57           C  
+ATOM   1380  OE1 GLU M 161     -20.479   0.971  24.385  1.00 30.49           O  
+ATOM   1381  OE2 GLU M 161     -18.518   0.759  25.352  1.00 28.46           O  
+ATOM   1382  N   GLY M 162     -20.384   0.260  18.581  1.00 18.30           N  
+ATOM   1383  CA  GLY M 162     -21.470   0.029  17.639  1.00 18.25           C  
+ATOM   1384  C   GLY M 162     -21.006  -0.164  16.204  1.00 18.23           C  
+ATOM   1385  O   GLY M 162     -20.561  -1.258  15.817  1.00 18.14           O  
+ATOM   1386  N   THR M 163     -21.111   0.907  15.425  1.00 16.92           N  
+ATOM   1387  CA  THR M 163     -20.753   0.914  14.018  1.00 17.13           C  
+ATOM   1388  C   THR M 163     -19.383   0.275  13.772  1.00 15.04           C  
+ATOM   1389  O   THR M 163     -19.230  -0.539  12.884  1.00 13.14           O  
+ATOM   1390  CB  THR M 163     -20.744   2.346  13.493  1.00 19.31           C  
+ATOM   1391  OG1 THR M 163     -22.066   2.891  13.618  1.00 21.88           O  
+ATOM   1392  CG2 THR M 163     -20.267   2.401  12.021  1.00 20.13           C  
+ATOM   1393  N   CYS M 164     -18.388   0.673  14.552  1.00 13.78           N  
+ATOM   1394  CA  CYS M 164     -17.023   0.201  14.342  1.00 14.75           C  
+ATOM   1395  C   CYS M 164     -16.950  -1.350  14.379  1.00 14.50           C  
+ATOM   1396  O   CYS M 164     -16.386  -1.987  13.483  1.00 13.98           O  
+ATOM   1397  CB  CYS M 164     -16.090   0.799  15.413  1.00 14.79           C  
+ATOM   1398  SG  CYS M 164     -14.339   0.544  15.070  1.00 16.58           S  
+ATOM   1399  N   VAL M 165     -17.503  -1.950  15.430  1.00 13.71           N  
+ATOM   1400  CA AVAL M 165     -17.513  -3.405  15.590  0.50 14.58           C  
+ATOM   1401  CA BVAL M 165     -17.430  -3.403  15.518  0.50 13.47           C  
+ATOM   1402  C   VAL M 165     -18.389  -4.099  14.548  1.00 13.05           C  
+ATOM   1403  O   VAL M 165     -18.098  -5.213  14.072  1.00 13.35           O  
+ATOM   1404  CB AVAL M 165     -18.052  -3.791  16.971  0.50 15.16           C  
+ATOM   1405  CB BVAL M 165     -17.588  -3.929  16.956  0.50 13.55           C  
+ATOM   1406  CG1AVAL M 165     -17.922  -5.280  17.176  0.50 16.90           C  
+ATOM   1407  CG1BVAL M 165     -16.337  -3.598  17.779  0.50 12.36           C  
+ATOM   1408  CG2AVAL M 165     -17.297  -3.062  18.050  0.50 17.33           C  
+ATOM   1409  CG2BVAL M 165     -18.853  -3.390  17.599  0.50 12.51           C  
+ATOM   1410  N   GLU M 166     -19.501  -3.463  14.225  1.00 12.93           N  
+ATOM   1411  CA  GLU M 166     -20.417  -4.063  13.250  1.00 14.42           C  
+ATOM   1412  C   GLU M 166     -19.724  -4.169  11.892  1.00 13.49           C  
+ATOM   1413  O   GLU M 166     -19.837  -5.176  11.216  1.00 12.36           O  
+ATOM   1414  CB  GLU M 166     -21.740  -3.293  13.162  1.00 17.04           C  
+ATOM   1415  CG  GLU M 166     -22.559  -3.439  14.465  1.00 21.68           C  
+ATOM   1416  CD  GLU M 166     -23.588  -2.328  14.683  1.00 27.14           C  
+ATOM   1417  OE1 GLU M 166     -23.768  -1.491  13.776  1.00 28.92           O  
+ATOM   1418  OE2 GLU M 166     -24.198  -2.291  15.781  1.00 29.80           O  
+ATOM   1419  N   TRP M 167     -18.996  -3.123  11.514  1.00 11.98           N  
+ATOM   1420  CA  TRP M 167     -18.315  -3.127  10.238  1.00 10.98           C  
+ATOM   1421  C   TRP M 167     -17.061  -4.008  10.218  1.00 10.62           C  
+ATOM   1422  O   TRP M 167     -16.767  -4.656   9.209  1.00  9.47           O  
+ATOM   1423  CB  TRP M 167     -18.061  -1.693   9.766  1.00 12.88           C  
+ATOM   1424  CG  TRP M 167     -19.320  -1.152   9.174  1.00 16.39           C  
+ATOM   1425  CD1 TRP M 167     -20.402  -0.674   9.863  1.00 17.72           C  
+ATOM   1426  CD2 TRP M 167     -19.674  -1.116   7.784  1.00 16.39           C  
+ATOM   1427  NE1 TRP M 167     -21.394  -0.306   8.977  1.00 18.36           N  
+ATOM   1428  CE2 TRP M 167     -20.977  -0.575   7.698  1.00 19.59           C  
+ATOM   1429  CE3 TRP M 167     -19.015  -1.474   6.604  1.00 16.72           C  
+ATOM   1430  CZ2 TRP M 167     -21.628  -0.370   6.474  1.00 18.70           C  
+ATOM   1431  CZ3 TRP M 167     -19.675  -1.276   5.379  1.00 16.79           C  
+ATOM   1432  CH2 TRP M 167     -20.961  -0.725   5.333  1.00 19.78           C  
+ATOM   1433  N   LEU M 168     -16.350  -4.074  11.343  1.00  9.40           N  
+ATOM   1434  CA  LEU M 168     -15.235  -4.986  11.458  1.00  9.22           C  
+ATOM   1435  C   LEU M 168     -15.729  -6.406  11.219  1.00  9.99           C  
+ATOM   1436  O   LEU M 168     -15.141  -7.152  10.449  1.00 10.49           O  
+ATOM   1437  CB  LEU M 168     -14.555  -4.867  12.835  1.00  7.74           C  
+ATOM   1438  CG  LEU M 168     -13.457  -5.889  13.132  1.00  7.55           C  
+ATOM   1439  CD1 LEU M 168     -12.311  -5.906  12.040  1.00  5.65           C  
+ATOM   1440  CD2 LEU M 168     -12.860  -5.564  14.514  1.00  8.46           C  
+ATOM   1441  N   ARG M 169     -16.839  -6.763  11.856  1.00 10.58           N  
+ATOM   1442  CA  ARG M 169     -17.368  -8.115  11.712  1.00 11.77           C  
+ATOM   1443  C   ARG M 169     -17.736  -8.390  10.250  1.00 10.99           C  
+ATOM   1444  O   ARG M 169     -17.555  -9.497   9.745  1.00 11.61           O  
+ATOM   1445  CB  ARG M 169     -18.592  -8.288  12.617  1.00 10.98           C  
+ATOM   1446  CG  ARG M 169     -18.196  -8.506  14.084  1.00 13.37           C  
+ATOM   1447  CD  ARG M 169     -19.365  -8.983  14.912  1.00 18.87           C  
+ATOM   1448  NE  ARG M 169     -20.336  -7.917  15.114  1.00 21.48           N  
+ATOM   1449  CZ  ARG M 169     -20.522  -7.271  16.260  1.00 25.34           C  
+ATOM   1450  NH1 ARG M 169     -19.782  -7.562  17.327  1.00 25.06           N  
+ATOM   1451  NH2 ARG M 169     -21.439  -6.308  16.331  1.00 26.19           N  
+ATOM   1452  N   ARG M 170     -18.291  -7.373   9.604  1.00 11.41           N  
+ATOM   1453  CA  ARG M 170     -18.700  -7.471   8.203  1.00 11.73           C  
+ATOM   1454  C   ARG M 170     -17.480  -7.705   7.322  1.00 11.28           C  
+ATOM   1455  O   ARG M 170     -17.482  -8.603   6.472  1.00 12.08           O  
+ATOM   1456  CB  ARG M 170     -19.424  -6.196   7.778  1.00 12.11           C  
+ATOM   1457  CG  ARG M 170     -19.828  -6.163   6.300  1.00 13.84           C  
+ATOM   1458  CD  ARG M 170     -20.130  -4.722   5.929  1.00 17.88           C  
+ATOM   1459  NE  ARG M 170     -20.610  -4.525   4.564  1.00 20.01           N  
+ATOM   1460  CZ  ARG M 170     -21.877  -4.242   4.278  1.00 24.86           C  
+ATOM   1461  NH1 ARG M 170     -22.768  -4.182   5.264  1.00 23.10           N  
+ATOM   1462  NH2 ARG M 170     -22.264  -4.042   3.018  1.00 26.71           N  
+ATOM   1463  N   TYR M 171     -16.437  -6.897   7.527  1.00 11.58           N  
+ATOM   1464  CA  TYR M 171     -15.172  -7.073   6.796  1.00 12.16           C  
+ATOM   1465  C   TYR M 171     -14.529  -8.440   7.015  1.00 11.65           C  
+ATOM   1466  O   TYR M 171     -14.007  -9.046   6.080  1.00 11.60           O  
+ATOM   1467  CB  TYR M 171     -14.144  -6.003   7.181  1.00 11.47           C  
+ATOM   1468  CG  TYR M 171     -14.567  -4.554   6.945  1.00 13.13           C  
+ATOM   1469  CD1 TYR M 171     -15.427  -4.206   5.892  1.00 11.72           C  
+ATOM   1470  CD2 TYR M 171     -14.068  -3.535   7.753  1.00 13.57           C  
+ATOM   1471  CE1 TYR M 171     -15.797  -2.849   5.679  1.00 13.78           C  
+ATOM   1472  CE2 TYR M 171     -14.428  -2.187   7.553  1.00 15.08           C  
+ATOM   1473  CZ  TYR M 171     -15.278  -1.855   6.509  1.00 14.48           C  
+ATOM   1474  OH  TYR M 171     -15.612  -0.531   6.318  1.00 15.42           O  
+ATOM   1475  N   LEU M 172     -14.513  -8.908   8.252  1.00 12.45           N  
+ATOM   1476  CA  LEU M 172     -13.901 -10.194   8.550  1.00 11.04           C  
+ATOM   1477  C   LEU M 172     -14.593 -11.299   7.773  1.00 12.74           C  
+ATOM   1478  O   LEU M 172     -13.931 -12.180   7.175  1.00 12.97           O  
+ATOM   1479  CB  LEU M 172     -13.971 -10.494  10.056  1.00 11.60           C  
+ATOM   1480  CG  LEU M 172     -13.040  -9.601  10.888  1.00 11.90           C  
+ATOM   1481  CD1 LEU M 172     -13.460  -9.608  12.344  1.00 12.76           C  
+ATOM   1482  CD2 LEU M 172     -11.573 -10.025  10.707  1.00 12.11           C  
+ATOM   1483  N   GLU M 173     -15.921 -11.253   7.771  1.00 11.87           N  
+ATOM   1484  CA  GLU M 173     -16.692 -12.245   6.999  1.00 14.03           C  
+ATOM   1485  C   GLU M 173     -16.452 -12.156   5.499  1.00 13.64           C  
+ATOM   1486  O   GLU M 173     -16.204 -13.159   4.845  1.00 14.26           O  
+ATOM   1487  CB  GLU M 173     -18.199 -12.132   7.275  1.00 14.28           C  
+ATOM   1488  CG  GLU M 173     -19.043 -12.980   6.305  1.00 18.76           C  
+ATOM   1489  CD  GLU M 173     -20.490 -13.100   6.761  1.00 23.25           C  
+ATOM   1490  OE1 GLU M 173     -21.237 -13.921   6.189  1.00 26.56           O  
+ATOM   1491  OE2 GLU M 173     -20.878 -12.370   7.697  1.00 23.90           O  
+ATOM   1492  N   ASN M 174     -16.555 -10.954   4.941  1.00 13.54           N  
+ATOM   1493  CA  ASN M 174     -16.391 -10.785   3.515  1.00 13.46           C  
+ATOM   1494  C   ASN M 174     -14.997 -11.189   3.111  1.00 14.50           C  
+ATOM   1495  O   ASN M 174     -14.806 -11.770   2.049  1.00 14.03           O  
+ATOM   1496  CB  ASN M 174     -16.684  -9.347   3.067  1.00 13.97           C  
+ATOM   1497  CG  ASN M 174     -18.173  -8.999   3.182  1.00 17.06           C  
+ATOM   1498  OD1 ASN M 174     -19.013  -9.885   3.355  1.00 17.89           O  
+ATOM   1499  ND2 ASN M 174     -18.490  -7.739   3.094  1.00 16.91           N  
+ATOM   1500  N   GLY M 175     -14.027 -10.883   3.963  1.00 15.22           N  
+ATOM   1501  CA  GLY M 175     -12.639 -11.141   3.611  1.00 16.50           C  
+ATOM   1502  C   GLY M 175     -12.079 -12.393   4.246  1.00 17.84           C  
+ATOM   1503  O   GLY M 175     -10.856 -12.518   4.361  1.00 18.36           O  
+ATOM   1504  N   LYS M 176     -12.949 -13.333   4.634  1.00 17.89           N  
+ATOM   1505  CA  LYS M 176     -12.506 -14.446   5.472  1.00 19.89           C  
+ATOM   1506  C   LYS M 176     -11.406 -15.283   4.831  1.00 20.80           C  
+ATOM   1507  O   LYS M 176     -10.522 -15.786   5.530  1.00 20.70           O  
+ATOM   1508  CB  LYS M 176     -13.680 -15.317   5.969  1.00 21.93           C  
+ATOM   1509  CG  LYS M 176     -14.535 -15.957   4.882  1.00 24.88           C  
+ATOM   1510  CD  LYS M 176     -15.642 -16.781   5.505  1.00 28.74           C  
+ATOM   1511  CE  LYS M 176     -16.018 -17.972   4.633  1.00 31.27           C  
+ATOM   1512  NZ  LYS M 176     -16.606 -17.506   3.368  1.00 32.66           N  
+ATOM   1513  N   GLU M 177     -11.426 -15.397   3.505  1.00 21.97           N  
+ATOM   1514  CA  GLU M 177     -10.447 -16.228   2.804  1.00 24.46           C  
+ATOM   1515  C   GLU M 177      -9.016 -15.824   3.096  1.00 23.29           C  
+ATOM   1516  O   GLU M 177      -8.118 -16.669   3.071  1.00 23.25           O  
+ATOM   1517  CB  GLU M 177     -10.683 -16.201   1.286  1.00 26.91           C  
+ATOM   1518  CG  GLU M 177     -12.043 -16.747   0.869  1.00 32.95           C  
+ATOM   1519  CD  GLU M 177     -12.301 -18.161   1.376  1.00 37.05           C  
+ATOM   1520  OE1 GLU M 177     -11.415 -19.035   1.196  1.00 39.39           O  
+ATOM   1521  OE2 GLU M 177     -13.396 -18.401   1.946  1.00 38.35           O  
+ATOM   1522  N   THR M 178      -8.799 -14.535   3.349  1.00 21.51           N  
+ATOM   1523  CA  THR M 178      -7.463 -14.027   3.658  1.00 21.97           C  
+ATOM   1524  C   THR M 178      -7.341 -13.481   5.082  1.00 22.23           C  
+ATOM   1525  O   THR M 178      -6.387 -13.797   5.768  1.00 23.00           O  
+ATOM   1526  CB  THR M 178      -6.999 -12.932   2.667  1.00 22.70           C  
+ATOM   1527  OG1 THR M 178      -7.998 -11.909   2.565  1.00 22.83           O  
+ATOM   1528  CG2 THR M 178      -6.764 -13.515   1.289  1.00 23.64           C  
+ATOM   1529  N   LEU M 179      -8.305 -12.683   5.538  1.00 21.18           N  
+ATOM   1530  CA  LEU M 179      -8.210 -12.082   6.869  1.00 20.07           C  
+ATOM   1531  C   LEU M 179      -8.178 -13.085   7.998  1.00 21.54           C  
+ATOM   1532  O   LEU M 179      -7.545 -12.851   9.024  1.00 21.68           O  
+ATOM   1533  CB  LEU M 179      -9.363 -11.114   7.126  1.00 19.58           C  
+ATOM   1534  CG  LEU M 179      -9.355  -9.858   6.272  1.00 15.72           C  
+ATOM   1535  CD1 LEU M 179     -10.611  -9.044   6.605  1.00 15.17           C  
+ATOM   1536  CD2 LEU M 179      -8.071  -9.063   6.504  1.00 15.20           C  
+ATOM   1537  N   GLN M 180      -8.871 -14.200   7.816  1.00 21.71           N  
+ATOM   1538  CA  GLN M 180      -8.964 -15.182   8.879  1.00 23.32           C  
+ATOM   1539  C   GLN M 180      -8.143 -16.409   8.542  1.00 23.73           C  
+ATOM   1540  O   GLN M 180      -8.294 -17.445   9.178  1.00 25.81           O  
+ATOM   1541  CB  GLN M 180     -10.423 -15.549   9.112  1.00 23.32           C  
+ATOM   1542  CG  GLN M 180     -11.277 -14.323   9.052  1.00 25.41           C  
+ATOM   1543  CD  GLN M 180     -12.553 -14.445   9.817  1.00 25.58           C  
+ATOM   1544  OE1 GLN M 180     -13.633 -14.204   9.275  1.00 26.82           O  
+ATOM   1545  NE2 GLN M 180     -12.451 -14.815  11.087  1.00 23.39           N  
+ATOM   1546  N   ARG M 181      -7.283 -16.292   7.534  1.00 24.14           N  
+ATOM   1547  CA  ARG M 181      -6.323 -17.345   7.216  1.00 23.56           C  
+ATOM   1548  C   ARG M 181      -5.010 -17.020   7.897  1.00 24.03           C  
+ATOM   1549  O   ARG M 181      -4.515 -15.903   7.788  1.00 24.58           O  
+ATOM   1550  CB  ARG M 181      -6.094 -17.424   5.709  1.00 24.68           C  
+ATOM   1551  CG  ARG M 181      -5.235 -18.604   5.247  1.00 28.01           C  
+ATOM   1552  CD  ARG M 181      -5.041 -18.577   3.723  1.00 28.96           C  
+ATOM   1553  NE  ARG M 181      -3.930 -17.709   3.332  1.00 30.75           N  
+ATOM   1554  CZ  ARG M 181      -3.872 -17.004   2.201  1.00 31.77           C  
+ATOM   1555  NH1 ARG M 181      -2.808 -16.248   1.937  1.00 30.31           N  
+ATOM   1556  NH2 ARG M 181      -4.875 -17.035   1.338  1.00 31.18           N  
+ATOM   1557  N   THR M 182      -4.432 -17.977   8.610  1.00 22.97           N  
+ATOM   1558  CA  THR M 182      -3.116 -17.731   9.165  1.00 22.39           C  
+ATOM   1559  C   THR M 182      -2.073 -18.346   8.244  1.00 21.17           C  
+ATOM   1560  O   THR M 182      -2.254 -19.448   7.717  1.00 19.91           O  
+ATOM   1561  CB  THR M 182      -2.974 -18.279  10.593  1.00 24.22           C  
+ATOM   1562  OG1 THR M 182      -3.390 -19.655  10.611  1.00 27.17           O  
+ATOM   1563  CG2 THR M 182      -3.840 -17.474  11.542  1.00 24.42           C  
+ATOM   1564  N   ASP M 183      -1.002 -17.603   8.008  1.00 18.77           N  
+ATOM   1565  CA  ASP M 183       0.117 -18.125   7.263  1.00 17.28           C  
+ATOM   1566  C   ASP M 183       1.277 -18.375   8.231  1.00 17.90           C  
+ATOM   1567  O   ASP M 183       1.941 -17.437   8.659  1.00 15.46           O  
+ATOM   1568  CB  ASP M 183       0.523 -17.154   6.154  1.00 18.43           C  
+ATOM   1569  CG  ASP M 183      -0.608 -16.897   5.147  1.00 21.06           C  
+ATOM   1570  OD1 ASP M 183      -1.631 -17.606   5.184  1.00 22.57           O  
+ATOM   1571  OD2 ASP M 183      -0.488 -15.973   4.332  1.00 19.99           O  
+ATOM   1572  N   ALA M 184       1.498 -19.648   8.570  1.00 16.42           N  
+ATOM   1573  CA  ALA M 184       2.648 -20.081   9.350  1.00 16.58           C  
+ATOM   1574  C   ALA M 184       3.930 -19.692   8.643  1.00 15.91           C  
+ATOM   1575  O   ALA M 184       4.001 -19.703   7.419  1.00 16.23           O  
+ATOM   1576  CB  ALA M 184       2.615 -21.615   9.553  1.00 17.07           C  
+ATOM   1577  N   PRO M 185       4.967 -19.354   9.408  1.00 15.53           N  
+ATOM   1578  CA  PRO M 185       6.197 -19.016   8.707  1.00 14.74           C  
+ATOM   1579  C   PRO M 185       6.830 -20.213   8.038  1.00 15.48           C  
+ATOM   1580  O   PRO M 185       6.772 -21.312   8.561  1.00 15.87           O  
+ATOM   1581  CB  PRO M 185       7.129 -18.533   9.830  1.00 13.62           C  
+ATOM   1582  CG  PRO M 185       6.573 -19.151  11.093  1.00 15.97           C  
+ATOM   1583  CD  PRO M 185       5.085 -19.215  10.871  1.00 14.46           C  
+ATOM   1584  N   LYS M 186       7.426 -19.987   6.875  1.00 15.94           N  
+ATOM   1585  CA ALYS M 186       8.242 -20.991   6.225  0.50 15.87           C  
+ATOM   1586  CA BLYS M 186       8.234 -21.003   6.242  0.50 16.07           C  
+ATOM   1587  C   LYS M 186       9.618 -20.747   6.797  1.00 15.97           C  
+ATOM   1588  O   LYS M 186      10.183 -19.685   6.576  1.00 14.60           O  
+ATOM   1589  CB ALYS M 186       8.307 -20.752   4.717  0.50 15.68           C  
+ATOM   1590  CB BLYS M 186       8.236 -20.833   4.723  0.50 16.17           C  
+ATOM   1591  CG ALYS M 186       6.981 -20.500   4.020  0.50 16.29           C  
+ATOM   1592  CG BLYS M 186       6.859 -20.875   4.072  0.50 17.42           C  
+ATOM   1593  CD ALYS M 186       7.208 -20.262   2.524  0.50 16.67           C  
+ATOM   1594  CD BLYS M 186       6.959 -21.121   2.562  0.50 18.71           C  
+ATOM   1595  CE ALYS M 186       5.943 -20.546   1.715  0.50 18.47           C  
+ATOM   1596  CE BLYS M 186       5.575 -21.230   1.915  0.50 18.10           C  
+ATOM   1597  NZ ALYS M 186       6.232 -20.574   0.248  0.50 17.41           N  
+ATOM   1598  NZ BLYS M 186       4.901 -19.910   1.858  0.50 18.29           N  
+ATOM   1599  N   THR M 187      10.149 -21.719   7.530  1.00 15.73           N  
+ATOM   1600  CA  THR M 187      11.401 -21.499   8.228  1.00 16.43           C  
+ATOM   1601  C   THR M 187      12.542 -22.312   7.616  1.00 17.47           C  
+ATOM   1602  O   THR M 187      12.328 -23.414   7.096  1.00 18.55           O  
+ATOM   1603  CB  THR M 187      11.299 -21.860   9.713  1.00 15.83           C  
+ATOM   1604  OG1 THR M 187      11.022 -23.257   9.835  1.00 18.40           O  
+ATOM   1605  CG2 THR M 187      10.170 -21.056  10.406  1.00 14.88           C  
+ATOM   1606  N   HIS M 188      13.736 -21.735   7.651  1.00 16.28           N  
+ATOM   1607  CA  HIS M 188      14.952 -22.440   7.264  1.00 17.17           C  
+ATOM   1608  C   HIS M 188      16.154 -21.790   7.920  1.00 17.37           C  
+ATOM   1609  O   HIS M 188      16.069 -20.665   8.440  1.00 15.53           O  
+ATOM   1610  CB  HIS M 188      15.121 -22.527   5.737  1.00 17.33           C  
+ATOM   1611  CG  HIS M 188      15.524 -21.244   5.078  1.00 18.92           C  
+ATOM   1612  ND1 HIS M 188      14.623 -20.244   4.778  1.00 19.69           N  
+ATOM   1613  CD2 HIS M 188      16.723 -20.821   4.613  1.00 19.19           C  
+ATOM   1614  CE1 HIS M 188      15.254 -19.245   4.192  1.00 19.99           C  
+ATOM   1615  NE2 HIS M 188      16.533 -19.567   4.087  1.00 21.13           N  
+ATOM   1616  N   MET M 189      17.273 -22.503   7.896  1.00 16.77           N  
+ATOM   1617  CA  MET M 189      18.472 -22.021   8.526  1.00 18.51           C  
+ATOM   1618  C   MET M 189      19.546 -21.916   7.452  1.00 18.19           C  
+ATOM   1619  O   MET M 189      19.631 -22.783   6.586  1.00 18.42           O  
+ATOM   1620  CB  MET M 189      18.892 -23.005   9.624  1.00 21.02           C  
+ATOM   1621  CG  MET M 189      19.493 -22.379  10.872  1.00 27.49           C  
+ATOM   1622  SD  MET M 189      19.848 -23.677  12.100  1.00 33.50           S  
+ATOM   1623  CE  MET M 189      18.250 -23.898  12.861  1.00 30.61           C  
+ATOM   1624  N   THR M 190      20.318 -20.837   7.461  1.00 17.26           N  
+ATOM   1625  CA  THR M 190      21.514 -20.778   6.621  1.00 18.19           C  
+ATOM   1626  C   THR M 190      22.771 -20.776   7.493  1.00 19.20           C  
+ATOM   1627  O   THR M 190      22.703 -20.450   8.672  1.00 17.24           O  
+ATOM   1628  CB  THR M 190      21.542 -19.564   5.671  1.00 18.55           C  
+ATOM   1629  OG1 THR M 190      21.559 -18.346   6.426  1.00 18.26           O  
+ATOM   1630  CG2 THR M 190      20.345 -19.586   4.730  1.00 18.56           C  
+ATOM   1631  N   HIS M 191      23.910 -21.129   6.890  1.00 19.39           N  
+ATOM   1632  CA  HIS M 191      25.165 -21.329   7.629  1.00 21.68           C  
+ATOM   1633  C   HIS M 191      26.268 -20.611   6.851  1.00 23.10           C  
+ATOM   1634  O   HIS M 191      26.392 -20.817   5.643  1.00 22.38           O  
+ATOM   1635  CB  HIS M 191      25.455 -22.831   7.742  1.00 22.51           C  
+ATOM   1636  CG  HIS M 191      26.734 -23.170   8.450  1.00 23.91           C  
+ATOM   1637  ND1 HIS M 191      27.960 -23.208   7.811  1.00 24.25           N  
+ATOM   1638  CD2 HIS M 191      26.972 -23.515   9.737  1.00 24.64           C  
+ATOM   1639  CE1 HIS M 191      28.898 -23.543   8.682  1.00 24.30           C  
+ATOM   1640  NE2 HIS M 191      28.323 -23.748   9.855  1.00 24.83           N  
+ATOM   1641  N   HIS M 192      27.009 -19.729   7.515  1.00 23.57           N  
+ATOM   1642  CA  HIS M 192      28.046 -18.929   6.852  1.00 27.21           C  
+ATOM   1643  C   HIS M 192      29.340 -18.947   7.660  1.00 26.73           C  
+ATOM   1644  O   HIS M 192      29.409 -18.345   8.719  1.00 28.10           O  
+ATOM   1645  CB  HIS M 192      27.606 -17.468   6.700  1.00 28.33           C  
+ATOM   1646  CG  HIS M 192      26.203 -17.303   6.195  1.00 32.73           C  
+ATOM   1647  ND1 HIS M 192      25.114 -17.229   7.039  1.00 34.01           N  
+ATOM   1648  CD2 HIS M 192      25.711 -17.205   4.935  1.00 33.55           C  
+ATOM   1649  CE1 HIS M 192      24.011 -17.092   6.320  1.00 35.35           C  
+ATOM   1650  NE2 HIS M 192      24.345 -17.073   5.041  1.00 34.56           N  
+ATOM   1651  N   ALA M 193      30.361 -19.625   7.154  1.00 27.02           N  
+ATOM   1652  CA  ALA M 193      31.667 -19.608   7.793  1.00 26.18           C  
+ATOM   1653  C   ALA M 193      32.225 -18.176   7.783  1.00 26.07           C  
+ATOM   1654  O   ALA M 193      32.256 -17.511   6.744  1.00 27.60           O  
+ATOM   1655  CB  ALA M 193      32.598 -20.572   7.097  1.00 25.66           C  
+ATOM   1656  N   VAL M 194      32.607 -17.669   8.944  1.00 24.87           N  
+ATOM   1657  CA  VAL M 194      33.221 -16.352   8.983  1.00 24.11           C  
+ATOM   1658  C   VAL M 194      34.729 -16.507   9.140  1.00 23.04           C  
+ATOM   1659  O   VAL M 194      35.483 -15.538   9.067  1.00 21.28           O  
+ATOM   1660  CB  VAL M 194      32.649 -15.452  10.082  1.00 24.77           C  
+ATOM   1661  CG1 VAL M 194      31.121 -15.382   9.984  1.00 24.79           C  
+ATOM   1662  CG2 VAL M 194      33.120 -15.912  11.462  1.00 25.64           C  
+ATOM   1663  N   SER M 195      35.147 -17.753   9.346  1.00 23.11           N  
+ATOM   1664  CA  SER M 195      36.554 -18.096   9.509  1.00 22.69           C  
+ATOM   1665  C   SER M 195      36.644 -19.610   9.490  1.00 23.46           C  
+ATOM   1666  O   SER M 195      35.636 -20.292   9.268  1.00 23.52           O  
+ATOM   1667  CB  SER M 195      37.108 -17.545  10.826  1.00 23.22           C  
+ATOM   1668  OG  SER M 195      36.725 -18.337  11.946  1.00 19.54           O  
+ATOM   1669  N   ASP M 196      37.843 -20.141   9.721  1.00 23.91           N  
+ATOM   1670  CA  ASP M 196      38.028 -21.579   9.804  1.00 24.85           C  
+ATOM   1671  C   ASP M 196      37.549 -22.125  11.140  1.00 24.23           C  
+ATOM   1672  O   ASP M 196      37.492 -23.334  11.315  1.00 25.03           O  
+ATOM   1673  CB  ASP M 196      39.505 -21.948   9.640  1.00 27.01           C  
+ATOM   1674  CG  ASP M 196      39.972 -21.868   8.197  1.00 29.32           C  
+ATOM   1675  OD1 ASP M 196      39.120 -21.919   7.279  1.00 30.30           O  
+ATOM   1676  OD2 ASP M 196      41.203 -21.772   7.990  1.00 31.65           O  
+ATOM   1677  N   HIS M 197      37.222 -21.245  12.084  1.00 22.72           N  
+ATOM   1678  CA  HIS M 197      36.915 -21.681  13.440  1.00 22.54           C  
+ATOM   1679  C   HIS M 197      35.550 -21.263  13.963  1.00 21.49           C  
+ATOM   1680  O   HIS M 197      35.151 -21.714  15.026  1.00 19.62           O  
+ATOM   1681  CB  HIS M 197      37.991 -21.209  14.420  1.00 24.77           C  
+ATOM   1682  CG  HIS M 197      39.343 -21.772  14.122  1.00 28.10           C  
+ATOM   1683  ND1 HIS M 197      39.676 -23.084  14.388  1.00 31.07           N  
+ATOM   1684  CD2 HIS M 197      40.435 -21.216  13.544  1.00 30.97           C  
+ATOM   1685  CE1 HIS M 197      40.919 -23.309  14.001  1.00 31.77           C  
+ATOM   1686  NE2 HIS M 197      41.402 -22.192  13.484  1.00 31.82           N  
+ATOM   1687  N   GLU M 198      34.855 -20.374  13.252  1.00 20.05           N  
+ATOM   1688  CA  GLU M 198      33.480 -20.054  13.647  1.00 19.60           C  
+ATOM   1689  C   GLU M 198      32.563 -19.779  12.453  1.00 19.48           C  
+ATOM   1690  O   GLU M 198      33.037 -19.593  11.319  1.00 18.46           O  
+ATOM   1691  CB  GLU M 198      33.422 -18.974  14.740  1.00 20.77           C  
+ATOM   1692  CG  GLU M 198      34.285 -17.763  14.513  1.00 23.34           C  
+ATOM   1693  CD  GLU M 198      35.706 -17.907  15.057  1.00 24.28           C  
+ATOM   1694  OE1 GLU M 198      36.642 -17.469  14.349  1.00 23.89           O  
+ATOM   1695  OE2 GLU M 198      35.891 -18.447  16.180  1.00 22.93           O  
+ATOM   1696  N   ALA M 199      31.253 -19.804  12.713  1.00 16.72           N  
+ATOM   1697  CA  ALA M 199      30.250 -19.731  11.659  1.00 17.19           C  
+ATOM   1698  C   ALA M 199      29.067 -18.924  12.157  1.00 17.72           C  
+ATOM   1699  O   ALA M 199      28.797 -18.883  13.360  1.00 17.35           O  
+ATOM   1700  CB  ALA M 199      29.767 -21.107  11.310  1.00 15.85           C  
+ATOM   1701  N   THR M 200      28.336 -18.330  11.224  1.00 17.18           N  
+ATOM   1702  CA  THR M 200      27.075 -17.665  11.571  1.00 17.71           C  
+ATOM   1703  C   THR M 200      25.935 -18.599  11.185  1.00 16.84           C  
+ATOM   1704  O   THR M 200      25.918 -19.135  10.082  1.00 17.12           O  
+ATOM   1705  CB  THR M 200      26.917 -16.314  10.838  1.00 17.74           C  
+ATOM   1706  OG1 THR M 200      27.890 -15.395  11.326  1.00 20.67           O  
+ATOM   1707  CG2 THR M 200      25.548 -15.702  11.106  1.00 17.93           C  
+ATOM   1708  N   LEU M 201      25.012 -18.819  12.116  1.00 15.46           N  
+ATOM   1709  CA  LEU M 201      23.788 -19.558  11.840  1.00 14.75           C  
+ATOM   1710  C   LEU M 201      22.666 -18.528  11.805  1.00 13.71           C  
+ATOM   1711  O   LEU M 201      22.515 -17.765  12.748  1.00 13.66           O  
+ATOM   1712  CB  LEU M 201      23.493 -20.558  12.963  1.00 15.56           C  
+ATOM   1713  CG  LEU M 201      24.495 -21.694  13.146  1.00 16.97           C  
+ATOM   1714  CD1 LEU M 201      24.085 -22.510  14.397  1.00 17.74           C  
+ATOM   1715  CD2 LEU M 201      24.461 -22.545  11.892  1.00 19.00           C  
+ATOM   1716  N   ARG M 202      21.898 -18.504  10.722  1.00 13.95           N  
+ATOM   1717  CA  ARG M 202      20.798 -17.546  10.575  1.00 13.71           C  
+ATOM   1718  C   ARG M 202      19.516 -18.338  10.407  1.00 14.05           C  
+ATOM   1719  O   ARG M 202      19.392 -19.143   9.469  1.00 15.04           O  
+ATOM   1720  CB  ARG M 202      21.007 -16.623   9.359  1.00 13.05           C  
+ATOM   1721  CG  ARG M 202      19.960 -15.481   9.232  1.00 14.27           C  
+ATOM   1722  CD  ARG M 202      20.389 -14.404   8.194  1.00 15.75           C  
+ATOM   1723  NE  ARG M 202      21.375 -13.512   8.784  1.00 16.54           N  
+ATOM   1724  CZ  ARG M 202      22.662 -13.476   8.426  1.00 18.68           C  
+ATOM   1725  NH1 ARG M 202      23.103 -14.227   7.432  1.00 17.75           N  
+ATOM   1726  NH2 ARG M 202      23.499 -12.652   9.037  1.00 19.75           N  
+ATOM   1727  N   CYS M 203      18.567 -18.084  11.297  1.00 13.79           N  
+ATOM   1728  CA  CYS M 203      17.276 -18.771  11.315  1.00 13.88           C  
+ATOM   1729  C   CYS M 203      16.227 -17.848  10.704  1.00 14.32           C  
+ATOM   1730  O   CYS M 203      16.042 -16.745  11.184  1.00 13.08           O  
+ATOM   1731  CB  CYS M 203      16.904 -19.068  12.759  1.00 14.99           C  
+ATOM   1732  SG  CYS M 203      15.332 -19.936  12.922  1.00 16.83           S  
+ATOM   1733  N   TRP M 204      15.594 -18.275   9.612  1.00 13.32           N  
+ATOM   1734  CA  TRP M 204      14.716 -17.397   8.824  1.00 13.15           C  
+ATOM   1735  C   TRP M 204      13.278 -17.797   8.991  1.00 12.55           C  
+ATOM   1736  O   TRP M 204      12.971 -18.987   8.938  1.00 11.16           O  
+ATOM   1737  CB  TRP M 204      15.014 -17.547   7.324  1.00 13.34           C  
+ATOM   1738  CG  TRP M 204      16.279 -16.930   6.793  1.00 15.15           C  
+ATOM   1739  CD1 TRP M 204      17.538 -17.483   6.788  1.00 15.43           C  
+ATOM   1740  CD2 TRP M 204      16.401 -15.655   6.154  1.00 15.89           C  
+ATOM   1741  NE1 TRP M 204      18.431 -16.615   6.193  1.00 15.24           N  
+ATOM   1742  CE2 TRP M 204      17.754 -15.496   5.781  1.00 17.10           C  
+ATOM   1743  CE3 TRP M 204      15.491 -14.645   5.836  1.00 15.46           C  
+ATOM   1744  CZ2 TRP M 204      18.220 -14.351   5.120  1.00 18.66           C  
+ATOM   1745  CZ3 TRP M 204      15.953 -13.514   5.188  1.00 18.76           C  
+ATOM   1746  CH2 TRP M 204      17.303 -13.376   4.836  1.00 18.60           C  
+ATOM   1747  N   ALA M 205      12.393 -16.801   9.142  1.00 11.33           N  
+ATOM   1748  CA  ALA M 205      10.947 -17.006   9.085  1.00 10.39           C  
+ATOM   1749  C   ALA M 205      10.410 -16.104   7.954  1.00 10.60           C  
+ATOM   1750  O   ALA M 205      10.606 -14.892   7.970  1.00 10.58           O  
+ATOM   1751  CB  ALA M 205      10.297 -16.648  10.409  1.00 10.28           C  
+ATOM   1752  N   LEU M 206       9.779 -16.719   6.966  1.00  9.57           N  
+ATOM   1753  CA  LEU M 206       9.331 -16.014   5.758  1.00 12.14           C  
+ATOM   1754  C   LEU M 206       7.843 -16.254   5.499  1.00 11.64           C  
+ATOM   1755  O   LEU M 206       7.289 -17.247   5.955  1.00 12.28           O  
+ATOM   1756  CB  LEU M 206      10.148 -16.476   4.539  1.00 11.96           C  
+ATOM   1757  CG  LEU M 206      11.649 -16.110   4.493  1.00 13.74           C  
+ATOM   1758  CD1 LEU M 206      12.388 -16.743   3.293  1.00 15.41           C  
+ATOM   1759  CD2 LEU M 206      11.833 -14.618   4.424  1.00 14.59           C  
+ATOM   1760  N   SER M 207       7.214 -15.298   4.808  1.00 12.87           N  
+ATOM   1761  CA ASER M 207       5.842 -15.445   4.295  0.50 13.73           C  
+ATOM   1762  CA BSER M 207       5.852 -15.438   4.286  0.50 12.93           C  
+ATOM   1763  C   SER M 207       4.821 -15.718   5.383  1.00 12.67           C  
+ATOM   1764  O   SER M 207       3.882 -16.471   5.176  1.00 14.82           O  
+ATOM   1765  CB ASER M 207       5.757 -16.573   3.254  0.50 14.83           C  
+ATOM   1766  CB BSER M 207       5.810 -16.523   3.186  0.50 13.41           C  
+ATOM   1767  OG ASER M 207       7.018 -16.835   2.691  0.50 17.57           O  
+ATOM   1768  OG BSER M 207       4.876 -16.204   2.166  0.50 12.00           O  
+ATOM   1769  N   PHE M 208       4.989 -15.095   6.550  1.00 10.24           N  
+ATOM   1770  CA  PHE M 208       4.043 -15.337   7.614  1.00  9.07           C  
+ATOM   1771  C   PHE M 208       3.024 -14.189   7.762  1.00  9.38           C  
+ATOM   1772  O   PHE M 208       3.274 -13.029   7.352  1.00  7.80           O  
+ATOM   1773  CB  PHE M 208       4.762 -15.707   8.926  1.00  9.27           C  
+ATOM   1774  CG  PHE M 208       5.723 -14.641   9.434  1.00  9.65           C  
+ATOM   1775  CD1 PHE M 208       5.267 -13.611  10.252  1.00  8.32           C  
+ATOM   1776  CD2 PHE M 208       7.075 -14.691   9.113  1.00  9.46           C  
+ATOM   1777  CE1 PHE M 208       6.126 -12.631  10.717  1.00  8.50           C  
+ATOM   1778  CE2 PHE M 208       7.977 -13.712   9.605  1.00 10.78           C  
+ATOM   1779  CZ  PHE M 208       7.481 -12.672  10.415  1.00  9.19           C  
+ATOM   1780  N   TYR M 209       1.868 -14.533   8.328  1.00  9.56           N  
+ATOM   1781  CA  TYR M 209       0.818 -13.557   8.593  1.00 10.74           C  
+ATOM   1782  C   TYR M 209      -0.047 -14.147   9.702  1.00 10.77           C  
+ATOM   1783  O   TYR M 209      -0.395 -15.314   9.641  1.00 12.53           O  
+ATOM   1784  CB  TYR M 209      -0.045 -13.280   7.350  1.00 10.14           C  
+ATOM   1785  CG  TYR M 209      -1.153 -12.292   7.649  1.00 11.26           C  
+ATOM   1786  CD1 TYR M 209      -1.016 -10.944   7.326  1.00  9.41           C  
+ATOM   1787  CD2 TYR M 209      -2.328 -12.707   8.273  1.00 11.58           C  
+ATOM   1788  CE1 TYR M 209      -2.015 -10.015   7.652  1.00  9.34           C  
+ATOM   1789  CE2 TYR M 209      -3.355 -11.791   8.572  1.00 10.46           C  
+ATOM   1790  CZ  TYR M 209      -3.181 -10.455   8.265  1.00 11.16           C  
+ATOM   1791  OH  TYR M 209      -4.163  -9.537   8.563  1.00 12.90           O  
+ATOM   1792  N   PRO M 210      -0.379 -13.348  10.719  1.00 12.28           N  
+ATOM   1793  CA  PRO M 210      -0.073 -11.929  10.930  1.00 12.33           C  
+ATOM   1794  C   PRO M 210       1.390 -11.660  11.324  1.00 11.84           C  
+ATOM   1795  O   PRO M 210       2.176 -12.596  11.419  1.00 11.72           O  
+ATOM   1796  CB  PRO M 210      -1.019 -11.554  12.094  1.00 13.33           C  
+ATOM   1797  CG  PRO M 210      -1.148 -12.816  12.844  1.00 14.77           C  
+ATOM   1798  CD  PRO M 210      -1.314 -13.845  11.754  1.00 13.04           C  
+ATOM   1799  N   ALA M 211       1.730 -10.391  11.559  1.00 12.31           N  
+ATOM   1800  CA  ALA M 211       3.144  -9.953  11.779  1.00 12.84           C  
+ATOM   1801  C   ALA M 211       3.758 -10.423  13.105  1.00 13.35           C  
+ATOM   1802  O   ALA M 211       4.968 -10.605  13.209  1.00 14.68           O  
+ATOM   1803  CB  ALA M 211       3.256  -8.428  11.677  1.00 11.02           C  
+ATOM   1804  N   GLU M 212       2.926 -10.611  14.121  1.00 14.26           N  
+ATOM   1805  CA  GLU M 212       3.430 -11.048  15.434  1.00 15.88           C  
+ATOM   1806  C   GLU M 212       4.151 -12.393  15.389  1.00 14.36           C  
+ATOM   1807  O   GLU M 212       3.632 -13.369  14.867  1.00 13.62           O  
+ATOM   1808  CB  GLU M 212       2.289 -11.139  16.449  1.00 17.78           C  
+ATOM   1809  CG  GLU M 212       2.790 -11.513  17.858  1.00 24.30           C  
+ATOM   1810  CD  GLU M 212       3.700 -10.444  18.467  1.00 29.31           C  
+ATOM   1811  OE1 GLU M 212       4.475 -10.781  19.391  1.00 33.54           O  
+ATOM   1812  OE2 GLU M 212       3.646  -9.260  18.030  1.00 33.60           O  
+ATOM   1813  N   ILE M 213       5.348 -12.435  15.955  1.00 14.02           N  
+ATOM   1814  CA  ILE M 213       6.158 -13.653  15.913  1.00 14.75           C  
+ATOM   1815  C   ILE M 213       7.249 -13.539  16.966  1.00 14.78           C  
+ATOM   1816  O   ILE M 213       7.674 -12.438  17.310  1.00 14.41           O  
+ATOM   1817  CB  ILE M 213       6.826 -13.844  14.523  1.00 14.41           C  
+ATOM   1818  CG1 ILE M 213       7.340 -15.281  14.363  1.00 13.93           C  
+ATOM   1819  CG2 ILE M 213       7.952 -12.816  14.352  1.00 13.44           C  
+ATOM   1820  CD1 ILE M 213       7.645 -15.682  12.906  1.00 13.78           C  
+ATOM   1821  N   THR M 214       7.716 -14.681  17.459  1.00 15.92           N  
+ATOM   1822  CA  THR M 214       8.914 -14.698  18.287  1.00 16.09           C  
+ATOM   1823  C   THR M 214       9.905 -15.707  17.742  1.00 15.31           C  
+ATOM   1824  O   THR M 214       9.540 -16.859  17.485  1.00 12.86           O  
+ATOM   1825  CB  THR M 214       8.589 -15.024  19.750  1.00 17.89           C  
+ATOM   1826  OG1 THR M 214       7.526 -14.160  20.176  1.00 18.81           O  
+ATOM   1827  CG2 THR M 214       9.828 -14.760  20.627  1.00 19.13           C  
+ATOM   1828  N   LEU M 215      11.132 -15.238  17.492  1.00 15.53           N  
+ATOM   1829  CA  LEU M 215      12.263 -16.101  17.133  1.00 15.67           C  
+ATOM   1830  C   LEU M 215      13.353 -15.956  18.185  1.00 16.38           C  
+ATOM   1831  O   LEU M 215      13.732 -14.834  18.559  1.00 15.32           O  
+ATOM   1832  CB  LEU M 215      12.900 -15.681  15.805  1.00 17.29           C  
+ATOM   1833  CG  LEU M 215      12.043 -15.542  14.571  1.00 17.84           C  
+ATOM   1834  CD1 LEU M 215      12.947 -15.116  13.403  1.00 16.36           C  
+ATOM   1835  CD2 LEU M 215      11.400 -16.868  14.294  1.00 17.99           C  
+ATOM   1836  N   THR M 216      13.869 -17.077  18.658  1.00 16.66           N  
+ATOM   1837  CA  THR M 216      14.871 -17.025  19.732  1.00 19.26           C  
+ATOM   1838  C   THR M 216      15.849 -18.182  19.544  1.00 18.97           C  
+ATOM   1839  O   THR M 216      15.487 -19.209  18.963  1.00 18.96           O  
+ATOM   1840  CB  THR M 216      14.221 -17.126  21.144  1.00 20.36           C  
+ATOM   1841  OG1 THR M 216      13.361 -18.262  21.191  1.00 24.34           O  
+ATOM   1842  CG2 THR M 216      13.390 -15.887  21.481  1.00 22.76           C  
+ATOM   1843  N   TRP M 217      17.089 -17.990  19.994  1.00 18.11           N  
+ATOM   1844  CA  TRP M 217      18.100 -19.048  19.943  1.00 18.27           C  
+ATOM   1845  C   TRP M 217      18.227 -19.635  21.335  1.00 18.31           C  
+ATOM   1846  O   TRP M 217      18.132 -18.914  22.324  1.00 18.39           O  
+ATOM   1847  CB  TRP M 217      19.478 -18.515  19.500  1.00 18.11           C  
+ATOM   1848  CG  TRP M 217      19.617 -18.377  18.013  1.00 17.89           C  
+ATOM   1849  CD1 TRP M 217      19.555 -17.217  17.282  1.00 18.03           C  
+ATOM   1850  CD2 TRP M 217      19.808 -19.434  17.071  1.00 19.18           C  
+ATOM   1851  NE1 TRP M 217      19.702 -17.497  15.950  1.00 17.86           N  
+ATOM   1852  CE2 TRP M 217      19.860 -18.845  15.787  1.00 18.39           C  
+ATOM   1853  CE3 TRP M 217      19.948 -20.821  17.183  1.00 17.54           C  
+ATOM   1854  CZ2 TRP M 217      20.040 -19.594  14.631  1.00 18.88           C  
+ATOM   1855  CZ3 TRP M 217      20.129 -21.571  16.016  1.00 19.01           C  
+ATOM   1856  CH2 TRP M 217      20.176 -20.949  14.762  1.00 19.55           C  
+ATOM   1857  N   GLN M 218      18.441 -20.943  21.392  1.00 18.09           N  
+ATOM   1858  CA  GLN M 218      18.876 -21.597  22.614  1.00 18.89           C  
+ATOM   1859  C   GLN M 218      20.194 -22.322  22.333  1.00 18.05           C  
+ATOM   1860  O   GLN M 218      20.466 -22.762  21.213  1.00 15.36           O  
+ATOM   1861  CB  GLN M 218      17.838 -22.608  23.112  1.00 20.31           C  
+ATOM   1862  CG  GLN M 218      16.600 -21.986  23.770  1.00 25.39           C  
+ATOM   1863  CD  GLN M 218      15.531 -23.026  24.101  1.00 29.84           C  
+ATOM   1864  OE1 GLN M 218      15.839 -24.143  24.526  1.00 31.50           O  
+ATOM   1865  NE2 GLN M 218      14.264 -22.662  23.893  1.00 31.36           N  
+ATOM   1866  N   ARG M 219      21.026 -22.416  23.365  1.00 18.24           N  
+ATOM   1867  CA AARG M 219      22.217 -23.245  23.299  0.50 18.80           C  
+ATOM   1868  CA BARG M 219      22.217 -23.256  23.300  0.50 18.99           C  
+ATOM   1869  C   ARG M 219      22.089 -24.268  24.416  1.00 20.19           C  
+ATOM   1870  O   ARG M 219      21.954 -23.890  25.581  1.00 20.37           O  
+ATOM   1871  CB AARG M 219      23.474 -22.385  23.477  0.50 18.13           C  
+ATOM   1872  CB BARG M 219      23.500 -22.437  23.482  0.50 18.65           C  
+ATOM   1873  CG AARG M 219      24.768 -23.085  23.046  0.50 17.49           C  
+ATOM   1874  CG BARG M 219      24.783 -23.251  23.195  0.50 18.36           C  
+ATOM   1875  CD AARG M 219      25.331 -23.918  24.166  0.50 14.52           C  
+ATOM   1876  CD BARG M 219      26.038 -22.479  23.547  0.50 16.69           C  
+ATOM   1877  NE AARG M 219      26.216 -23.126  25.016  0.50 12.24           N  
+ATOM   1878  NE BARG M 219      26.268 -22.422  24.987  0.50 14.18           N  
+ATOM   1879  CZ AARG M 219      27.025 -23.656  25.927  0.50  9.98           C  
+ATOM   1880  CZ BARG M 219      25.996 -21.372  25.752  0.50 15.03           C  
+ATOM   1881  NH1AARG M 219      27.045 -24.972  26.107  0.50  4.34           N  
+ATOM   1882  NH1BARG M 219      25.492 -20.278  25.221  0.50 10.58           N  
+ATOM   1883  NH2AARG M 219      27.810 -22.866  26.647  0.50 10.96           N  
+ATOM   1884  NH2BARG M 219      26.244 -21.418  27.056  0.50 16.12           N  
+ATOM   1885  N   ASP M 220      22.114 -25.548  24.055  1.00 21.29           N  
+ATOM   1886  CA  ASP M 220      21.916 -26.621  25.024  1.00 24.50           C  
+ATOM   1887  C   ASP M 220      20.661 -26.380  25.870  1.00 26.01           C  
+ATOM   1888  O   ASP M 220      20.664 -26.586  27.081  1.00 27.15           O  
+ATOM   1889  CB  ASP M 220      23.202 -26.837  25.859  1.00 24.23           C  
+ATOM   1890  CG  ASP M 220      24.364 -27.364  24.994  1.00 24.13           C  
+ATOM   1891  OD1 ASP M 220      24.074 -28.021  23.968  1.00 25.82           O  
+ATOM   1892  OD2 ASP M 220      25.556 -27.132  25.298  1.00 24.25           O  
+ATOM   1893  N   GLY M 221      19.593 -25.913  25.216  1.00 27.30           N  
+ATOM   1894  CA  GLY M 221      18.280 -25.779  25.843  1.00 29.64           C  
+ATOM   1895  C   GLY M 221      18.084 -24.565  26.739  1.00 31.84           C  
+ATOM   1896  O   GLY M 221      17.108 -24.490  27.486  1.00 31.81           O  
+ATOM   1897  N   GLU M 222      19.002 -23.609  26.672  1.00 32.26           N  
+ATOM   1898  CA  GLU M 222      18.839 -22.369  27.422  1.00 34.13           C  
+ATOM   1899  C   GLU M 222      18.886 -21.140  26.501  1.00 33.20           C  
+ATOM   1900  O   GLU M 222      19.675 -21.076  25.555  1.00 31.60           O  
+ATOM   1901  CB  GLU M 222      19.890 -22.281  28.534  1.00 35.79           C  
+ATOM   1902  CG  GLU M 222      20.184 -20.875  29.050  1.00 40.60           C  
+ATOM   1903  CD  GLU M 222      19.164 -20.377  30.065  1.00 42.84           C  
+ATOM   1904  OE1 GLU M 222      17.945 -20.444  29.785  1.00 44.10           O  
+ATOM   1905  OE2 GLU M 222      19.594 -19.893  31.138  1.00 44.95           O  
+ATOM   1906  N   ASP M 223      18.034 -20.164  26.789  1.00 33.14           N  
+ATOM   1907  CA  ASP M 223      17.944 -18.982  25.941  1.00 33.23           C  
+ATOM   1908  C   ASP M 223      19.290 -18.316  25.789  1.00 31.88           C  
+ATOM   1909  O   ASP M 223      20.043 -18.148  26.754  1.00 31.64           O  
+ATOM   1910  CB  ASP M 223      16.931 -17.985  26.486  1.00 34.31           C  
+ATOM   1911  CG  ASP M 223      15.517 -18.470  26.341  1.00 37.52           C  
+ATOM   1912  OD1 ASP M 223      15.121 -18.856  25.215  1.00 38.10           O  
+ATOM   1913  OD2 ASP M 223      14.799 -18.468  27.364  1.00 40.24           O  
+ATOM   1914  N   GLN M 224      19.603 -17.952  24.560  1.00 30.69           N  
+ATOM   1915  CA  GLN M 224      20.867 -17.318  24.297  1.00 29.68           C  
+ATOM   1916  C   GLN M 224      20.657 -16.002  23.574  1.00 29.44           C  
+ATOM   1917  O   GLN M 224      20.132 -15.965  22.459  1.00 28.96           O  
+ATOM   1918  CB  GLN M 224      21.775 -18.234  23.482  1.00 29.46           C  
+ATOM   1919  CG  GLN M 224      22.846 -17.455  22.779  1.00 30.69           C  
+ATOM   1920  CD  GLN M 224      24.209 -18.094  22.859  1.00 31.72           C  
+ATOM   1921  OE1 GLN M 224      24.375 -19.181  23.424  1.00 31.49           O  
+ATOM   1922  NE2 GLN M 224      25.204 -17.414  22.297  1.00 31.16           N  
+ATOM   1923  N   THR M 225      21.075 -14.917  24.208  1.00 28.89           N  
+ATOM   1924  CA  THR M 225      20.980 -13.601  23.570  1.00 29.90           C  
+ATOM   1925  C   THR M 225      22.345 -13.020  23.210  1.00 28.42           C  
+ATOM   1926  O   THR M 225      22.463 -12.249  22.265  1.00 28.58           O  
+ATOM   1927  CB  THR M 225      20.217 -12.600  24.450  1.00 29.95           C  
+ATOM   1928  OG1 THR M 225      20.834 -12.542  25.742  1.00 31.40           O  
+ATOM   1929  CG2 THR M 225      18.775 -13.046  24.608  1.00 31.91           C  
+ATOM   1930  N   GLN M 226      23.374 -13.363  23.972  1.00 27.63           N  
+ATOM   1931  CA  GLN M 226      24.711 -12.907  23.609  1.00 25.95           C  
+ATOM   1932  C   GLN M 226      25.127 -13.461  22.257  1.00 24.09           C  
+ATOM   1933  O   GLN M 226      24.825 -14.615  21.916  1.00 23.12           O  
+ATOM   1934  CB  GLN M 226      25.742 -13.329  24.652  1.00 27.03           C  
+ATOM   1935  CG  GLN M 226      25.824 -12.401  25.865  1.00 27.34           C  
+ATOM   1936  CD  GLN M 226      26.968 -12.798  26.751  1.00 27.30           C  
+ATOM   1937  OE1 GLN M 226      27.105 -13.960  27.094  1.00 27.97           O  
+ATOM   1938  NE2 GLN M 226      27.807 -11.845  27.106  1.00 26.97           N  
+ATOM   1939  N   ASP M 227      25.834 -12.630  21.503  1.00 22.71           N  
+ATOM   1940  CA  ASP M 227      26.352 -13.021  20.200  1.00 21.98           C  
+ATOM   1941  C   ASP M 227      25.248 -13.338  19.187  1.00 21.50           C  
+ATOM   1942  O   ASP M 227      25.489 -14.077  18.213  1.00 18.61           O  
+ATOM   1943  CB  ASP M 227      27.307 -14.213  20.334  1.00 21.99           C  
+ATOM   1944  CG  ASP M 227      28.451 -13.931  21.283  1.00 22.14           C  
+ATOM   1945  OD1 ASP M 227      29.125 -12.887  21.123  1.00 22.48           O  
+ATOM   1946  OD2 ASP M 227      28.679 -14.763  22.184  1.00 22.63           O  
+ATOM   1947  N   THR M 228      24.054 -12.789  19.415  1.00 20.34           N  
+ATOM   1948  CA  THR M 228      22.975 -12.904  18.410  1.00 21.61           C  
+ATOM   1949  C   THR M 228      22.635 -11.563  17.810  1.00 20.80           C  
+ATOM   1950  O   THR M 228      22.956 -10.522  18.384  1.00 20.85           O  
+ATOM   1951  CB  THR M 228      21.672 -13.541  18.962  1.00 22.79           C  
+ATOM   1952  OG1 THR M 228      21.027 -12.637  19.855  1.00 23.28           O  
+ATOM   1953  CG2 THR M 228      21.971 -14.856  19.688  1.00 22.03           C  
+ATOM   1954  N   GLU M 229      22.023 -11.592  16.631  1.00 20.17           N  
+ATOM   1955  CA  GLU M 229      21.452 -10.404  16.029  1.00 21.27           C  
+ATOM   1956  C   GLU M 229      20.022 -10.738  15.585  1.00 20.63           C  
+ATOM   1957  O   GLU M 229      19.785 -11.815  15.052  1.00 17.57           O  
+ATOM   1958  CB  GLU M 229      22.280  -9.897  14.851  1.00 23.11           C  
+ATOM   1959  CG  GLU M 229      21.502  -8.818  14.088  1.00 27.99           C  
+ATOM   1960  CD  GLU M 229      22.252  -8.188  12.923  1.00 32.37           C  
+ATOM   1961  OE1 GLU M 229      23.321  -8.711  12.535  1.00 33.46           O  
+ATOM   1962  OE2 GLU M 229      21.750  -7.158  12.392  1.00 34.70           O  
+ATOM   1963  N   LEU M 230      19.076  -9.834  15.851  1.00 20.56           N  
+ATOM   1964  CA  LEU M 230      17.653 -10.048  15.518  1.00 21.33           C  
+ATOM   1965  C   LEU M 230      17.143  -8.833  14.757  1.00 20.71           C  
+ATOM   1966  O   LEU M 230      17.164  -7.744  15.318  1.00 21.09           O  
+ATOM   1967  CB  LEU M 230      16.837 -10.202  16.807  1.00 22.24           C  
+ATOM   1968  CG  LEU M 230      15.308 -10.361  16.798  1.00 24.37           C  
+ATOM   1969  CD1 LEU M 230      14.855 -11.765  16.409  1.00 23.54           C  
+ATOM   1970  CD2 LEU M 230      14.741 -10.034  18.153  1.00 26.14           C  
+ATOM   1971  N   VAL M 231      16.721  -8.987  13.495  1.00 18.69           N  
+ATOM   1972  CA  VAL M 231      16.209  -7.828  12.730  1.00 16.37           C  
+ATOM   1973  C   VAL M 231      14.744  -7.569  13.044  1.00 15.81           C  
+ATOM   1974  O   VAL M 231      14.015  -8.465  13.485  1.00 15.69           O  
+ATOM   1975  CB  VAL M 231      16.373  -7.963  11.195  1.00 15.64           C  
+ATOM   1976  CG1 VAL M 231      17.842  -8.023  10.817  1.00 16.30           C  
+ATOM   1977  CG2 VAL M 231      15.607  -9.175  10.655  1.00 14.22           C  
+ATOM   1978  N   GLU M 232      14.310  -6.334  12.835  1.00 14.85           N  
+ATOM   1979  CA AGLU M 232      12.920  -5.960  13.051  0.50 13.89           C  
+ATOM   1980  CA BGLU M 232      12.921  -6.031  13.106  0.50 15.03           C  
+ATOM   1981  C   GLU M 232      12.042  -6.661  12.013  1.00 13.60           C  
+ATOM   1982  O   GLU M 232      12.459  -6.843  10.874  1.00 12.90           O  
+ATOM   1983  CB AGLU M 232      12.774  -4.439  12.960  0.50 13.88           C  
+ATOM   1984  CB BGLU M 232      12.691  -4.524  13.341  0.50 16.67           C  
+ATOM   1985  CG AGLU M 232      13.565  -3.708  14.044  0.50 14.54           C  
+ATOM   1986  CG BGLU M 232      12.255  -3.676  12.173  0.50 20.57           C  
+ATOM   1987  CD AGLU M 232      13.250  -2.220  14.149  0.50 18.33           C  
+ATOM   1988  CD BGLU M 232      11.804  -2.271  12.610  0.50 21.77           C  
+ATOM   1989  OE1AGLU M 232      12.904  -1.586  13.120  0.50 19.74           O  
+ATOM   1990  OE1BGLU M 232      11.677  -2.026  13.833  0.50 25.15           O  
+ATOM   1991  OE2AGLU M 232      13.361  -1.678  15.273  0.50 18.19           O  
+ATOM   1992  OE2BGLU M 232      11.577  -1.414  11.738  0.50 20.49           O  
+ATOM   1993  N   THR M 233      10.844  -7.075  12.408  1.00 12.57           N  
+ATOM   1994  CA  THR M 233       9.948  -7.706  11.448  1.00 11.59           C  
+ATOM   1995  C   THR M 233       9.673  -6.727  10.322  1.00 11.06           C  
+ATOM   1996  O   THR M 233       9.509  -5.522  10.564  1.00  9.99           O  
+ATOM   1997  CB  THR M 233       8.649  -8.094  12.152  1.00 11.67           C  
+ATOM   1998  OG1 THR M 233       8.971  -8.957  13.256  1.00 13.09           O  
+ATOM   1999  CG2 THR M 233       7.655  -8.757  11.177  1.00  9.68           C  
+ATOM   2000  N   ARG M 234       9.626  -7.235   9.088  1.00 10.60           N  
+ATOM   2001  CA  ARG M 234       9.581  -6.384   7.907  1.00  9.52           C  
+ATOM   2002  C   ARG M 234       8.602  -6.941   6.882  1.00  9.28           C  
+ATOM   2003  O   ARG M 234       8.468  -8.158   6.746  1.00  9.21           O  
+ATOM   2004  CB  ARG M 234      10.982  -6.276   7.285  1.00 10.85           C  
+ATOM   2005  CG  ARG M 234      11.547  -7.645   6.841  1.00  8.67           C  
+ATOM   2006  CD  ARG M 234      13.069  -7.588   6.620  1.00 10.74           C  
+ATOM   2007  NE  ARG M 234      13.550  -8.744   5.840  1.00 10.51           N  
+ATOM   2008  CZ  ARG M 234      14.834  -9.053   5.671  1.00 12.54           C  
+ATOM   2009  NH1 ARG M 234      15.781  -8.310   6.259  1.00 10.83           N  
+ATOM   2010  NH2 ARG M 234      15.168 -10.100   4.900  1.00 13.35           N  
+ATOM   2011  N   PRO M 235       7.890  -6.049   6.173  1.00  9.64           N  
+ATOM   2012  CA  PRO M 235       6.932  -6.481   5.130  1.00  9.75           C  
+ATOM   2013  C   PRO M 235       7.619  -7.072   3.884  1.00 10.22           C  
+ATOM   2014  O   PRO M 235       8.618  -6.525   3.411  1.00 11.01           O  
+ATOM   2015  CB  PRO M 235       6.220  -5.170   4.756  1.00 11.25           C  
+ATOM   2016  CG  PRO M 235       7.222  -4.087   5.080  1.00 10.90           C  
+ATOM   2017  CD  PRO M 235       7.881  -4.584   6.362  1.00  9.76           C  
+ATOM   2018  N   ALA M 236       7.083  -8.166   3.341  1.00 10.02           N  
+ATOM   2019  CA  ALA M 236       7.679  -8.773   2.136  1.00 10.16           C  
+ATOM   2020  C   ALA M 236       7.198  -8.015   0.914  1.00 10.41           C  
+ATOM   2021  O   ALA M 236       7.838  -8.049  -0.133  1.00 11.16           O  
+ATOM   2022  CB  ALA M 236       7.309 -10.234   2.013  1.00  9.18           C  
+ATOM   2023  N   GLY M 237       6.067  -7.318   1.066  1.00  9.93           N  
+ATOM   2024  CA  GLY M 237       5.472  -6.571  -0.043  1.00 11.33           C  
+ATOM   2025  C   GLY M 237       4.273  -7.238  -0.701  1.00 12.63           C  
+ATOM   2026  O   GLY M 237       3.595  -6.622  -1.532  1.00 12.62           O  
+ATOM   2027  N   ASP M 238       4.021  -8.507  -0.356  1.00 12.71           N  
+ATOM   2028  CA  ASP M 238       2.884  -9.257  -0.894  1.00 12.14           C  
+ATOM   2029  C   ASP M 238       1.856  -9.515   0.221  1.00 13.54           C  
+ATOM   2030  O   ASP M 238       1.026 -10.419   0.120  1.00 13.46           O  
+ATOM   2031  CB  ASP M 238       3.355 -10.576  -1.511  1.00 11.80           C  
+ATOM   2032  CG  ASP M 238       4.078 -11.478  -0.496  1.00 13.39           C  
+ATOM   2033  OD1 ASP M 238       4.117 -11.122   0.708  1.00 12.51           O  
+ATOM   2034  OD2 ASP M 238       4.573 -12.549  -0.885  1.00 14.73           O  
+ATOM   2035  N   GLY M 239       1.947  -8.731   1.289  1.00 12.48           N  
+ATOM   2036  CA  GLY M 239       0.987  -8.845   2.406  1.00 13.19           C  
+ATOM   2037  C   GLY M 239       1.496  -9.694   3.558  1.00 12.97           C  
+ATOM   2038  O   GLY M 239       0.856  -9.742   4.615  1.00 13.08           O  
+ATOM   2039  N   THR M 240       2.615 -10.397   3.340  1.00 11.96           N  
+ATOM   2040  CA  THR M 240       3.219 -11.236   4.377  1.00 10.36           C  
+ATOM   2041  C   THR M 240       4.439 -10.534   4.980  1.00 10.48           C  
+ATOM   2042  O   THR M 240       4.835  -9.456   4.528  1.00 10.36           O  
+ATOM   2043  CB  THR M 240       3.696 -12.621   3.837  1.00 11.99           C  
+ATOM   2044  OG1 THR M 240       4.781 -12.449   2.912  1.00 12.01           O  
+ATOM   2045  CG2 THR M 240       2.550 -13.378   3.164  1.00 13.21           C  
+ATOM   2046  N   PHE M 241       5.039 -11.170   5.988  1.00  8.66           N  
+ATOM   2047  CA  PHE M 241       6.116 -10.580   6.755  1.00  7.63           C  
+ATOM   2048  C   PHE M 241       7.294 -11.543   6.838  1.00  8.20           C  
+ATOM   2049  O   PHE M 241       7.142 -12.747   6.597  1.00  7.87           O  
+ATOM   2050  CB  PHE M 241       5.590 -10.243   8.169  1.00  7.57           C  
+ATOM   2051  CG  PHE M 241       4.524  -9.182   8.134  1.00  7.83           C  
+ATOM   2052  CD1 PHE M 241       3.189  -9.532   8.017  1.00  7.22           C  
+ATOM   2053  CD2 PHE M 241       4.895  -7.825   8.108  1.00  9.13           C  
+ATOM   2054  CE1 PHE M 241       2.215  -8.536   7.914  1.00  9.65           C  
+ATOM   2055  CE2 PHE M 241       3.934  -6.826   8.000  1.00 11.10           C  
+ATOM   2056  CZ  PHE M 241       2.575  -7.195   7.924  1.00 10.02           C  
+ATOM   2057  N   GLN M 242       8.443 -10.994   7.223  1.00  9.33           N  
+ATOM   2058  CA  GLN M 242       9.716 -11.728   7.316  1.00  8.20           C  
+ATOM   2059  C   GLN M 242      10.443 -11.332   8.594  1.00  8.88           C  
+ATOM   2060  O   GLN M 242      10.330 -10.196   9.047  1.00  7.81           O  
+ATOM   2061  CB  GLN M 242      10.644 -11.335   6.167  1.00  8.57           C  
+ATOM   2062  CG  GLN M 242      10.045 -11.376   4.759  1.00 11.48           C  
+ATOM   2063  CD  GLN M 242      11.086 -11.049   3.706  1.00 11.92           C  
+ATOM   2064  OE1 GLN M 242      12.163 -10.557   4.038  1.00  8.56           O  
+ATOM   2065  NE2 GLN M 242      10.780 -11.337   2.431  1.00 13.25           N  
+ATOM   2066  N   LYS M 243      11.276 -12.249   9.102  1.00  8.47           N  
+ATOM   2067  CA  LYS M 243      12.170 -11.939  10.202  1.00  9.74           C  
+ATOM   2068  C   LYS M 243      13.326 -12.953  10.188  1.00 10.47           C  
+ATOM   2069  O   LYS M 243      13.155 -14.081   9.710  1.00 10.33           O  
+ATOM   2070  CB  LYS M 243      11.406 -12.025  11.527  1.00  8.96           C  
+ATOM   2071  CG  LYS M 243      12.084 -11.282  12.702  1.00 11.72           C  
+ATOM   2072  CD  LYS M 243      11.237 -11.451  13.973  1.00 11.20           C  
+ATOM   2073  CE  LYS M 243      11.795 -10.618  15.115  1.00 13.08           C  
+ATOM   2074  NZ  LYS M 243      11.582  -9.167  14.877  1.00 15.03           N  
+ATOM   2075  N   TRP M 244      14.485 -12.557  10.707  1.00 11.37           N  
+ATOM   2076  CA  TRP M 244      15.550 -13.537  10.970  1.00 11.50           C  
+ATOM   2077  C   TRP M 244      16.277 -13.244  12.278  1.00 11.28           C  
+ATOM   2078  O   TRP M 244      16.304 -12.104  12.739  1.00 10.54           O  
+ATOM   2079  CB  TRP M 244      16.537 -13.696   9.791  1.00 10.77           C  
+ATOM   2080  CG  TRP M 244      17.321 -12.490   9.327  1.00 12.30           C  
+ATOM   2081  CD1 TRP M 244      17.085 -11.771   8.194  1.00 12.26           C  
+ATOM   2082  CD2 TRP M 244      18.496 -11.913   9.929  1.00 12.96           C  
+ATOM   2083  NE1 TRP M 244      18.034 -10.781   8.055  1.00 14.23           N  
+ATOM   2084  CE2 TRP M 244      18.903 -10.841   9.108  1.00 12.48           C  
+ATOM   2085  CE3 TRP M 244      19.239 -12.195  11.081  1.00 13.38           C  
+ATOM   2086  CZ2 TRP M 244      20.018 -10.044   9.403  1.00 14.13           C  
+ATOM   2087  CZ3 TRP M 244      20.340 -11.401  11.372  1.00 13.70           C  
+ATOM   2088  CH2 TRP M 244      20.718 -10.342  10.538  1.00 12.65           C  
+ATOM   2089  N   VAL M 245      16.824 -14.290  12.887  1.00 11.74           N  
+ATOM   2090  CA  VAL M 245      17.698 -14.115  14.030  1.00 12.16           C  
+ATOM   2091  C   VAL M 245      19.000 -14.908  13.755  1.00 13.97           C  
+ATOM   2092  O   VAL M 245      18.943 -16.025  13.239  1.00 12.74           O  
+ATOM   2093  CB  VAL M 245      17.001 -14.520  15.348  1.00 14.31           C  
+ATOM   2094  CG1 VAL M 245      16.576 -16.020  15.376  1.00 14.64           C  
+ATOM   2095  CG2 VAL M 245      17.901 -14.181  16.550  1.00 14.19           C  
+ATOM   2096  N   ALA M 246      20.160 -14.317  14.045  1.00 12.07           N  
+ATOM   2097  CA  ALA M 246      21.430 -15.012  13.807  1.00 12.81           C  
+ATOM   2098  C   ALA M 246      22.267 -15.146  15.080  1.00 13.38           C  
+ATOM   2099  O   ALA M 246      22.123 -14.371  16.010  1.00 12.29           O  
+ATOM   2100  CB  ALA M 246      22.240 -14.297  12.714  1.00 13.57           C  
+ATOM   2101  N   VAL M 247      23.128 -16.160  15.113  1.00 13.96           N  
+ATOM   2102  CA  VAL M 247      24.047 -16.361  16.232  1.00 13.53           C  
+ATOM   2103  C   VAL M 247      25.400 -16.778  15.639  1.00 13.78           C  
+ATOM   2104  O   VAL M 247      25.445 -17.384  14.578  1.00 13.20           O  
+ATOM   2105  CB  VAL M 247      23.524 -17.427  17.221  1.00 14.07           C  
+ATOM   2106  CG1 VAL M 247      23.453 -18.806  16.541  1.00 13.09           C  
+ATOM   2107  CG2 VAL M 247      24.369 -17.459  18.487  1.00 14.35           C  
+ATOM   2108  N   VAL M 248      26.497 -16.379  16.283  1.00 13.65           N  
+ATOM   2109  CA  VAL M 248      27.838 -16.790  15.832  1.00 13.89           C  
+ATOM   2110  C   VAL M 248      28.271 -17.898  16.777  1.00 12.94           C  
+ATOM   2111  O   VAL M 248      28.109 -17.786  18.010  1.00 13.47           O  
+ATOM   2112  CB  VAL M 248      28.849 -15.638  15.942  1.00 15.78           C  
+ATOM   2113  CG1 VAL M 248      30.199 -16.047  15.384  1.00 16.92           C  
+ATOM   2114  CG2 VAL M 248      28.301 -14.365  15.250  1.00 19.38           C  
+ATOM   2115  N   VAL M 249      28.791 -18.973  16.213  1.00 13.27           N  
+ATOM   2116  CA  VAL M 249      29.114 -20.148  17.004  1.00 13.71           C  
+ATOM   2117  C   VAL M 249      30.444 -20.750  16.592  1.00 13.84           C  
+ATOM   2118  O   VAL M 249      30.887 -20.551  15.460  1.00 12.80           O  
+ATOM   2119  CB  VAL M 249      28.040 -21.234  16.862  1.00 14.34           C  
+ATOM   2120  CG1 VAL M 249      26.634 -20.653  17.100  1.00 16.20           C  
+ATOM   2121  CG2 VAL M 249      28.117 -21.871  15.510  1.00 15.36           C  
+ATOM   2122  N   PRO M 250      31.079 -21.507  17.504  1.00 13.30           N  
+ATOM   2123  CA  PRO M 250      32.317 -22.184  17.069  1.00 14.05           C  
+ATOM   2124  C   PRO M 250      32.041 -23.299  16.082  1.00 15.25           C  
+ATOM   2125  O   PRO M 250      31.076 -24.063  16.242  1.00 14.72           O  
+ATOM   2126  CB  PRO M 250      32.915 -22.742  18.376  1.00 13.10           C  
+ATOM   2127  CG  PRO M 250      32.253 -21.963  19.491  1.00 12.51           C  
+ATOM   2128  CD  PRO M 250      30.847 -21.629  18.956  1.00 14.20           C  
+ATOM   2129  N   SER M 251      32.892 -23.393  15.061  1.00 18.72           N  
+ATOM   2130  CA  SER M 251      32.742 -24.399  14.015  1.00 20.86           C  
+ATOM   2131  C   SER M 251      32.720 -25.780  14.620  1.00 21.14           C  
+ATOM   2132  O   SER M 251      33.585 -26.110  15.429  1.00 21.52           O  
+ATOM   2133  CB  SER M 251      33.919 -24.321  13.039  1.00 22.37           C  
+ATOM   2134  OG  SER M 251      33.774 -23.189  12.218  1.00 28.37           O  
+ATOM   2135  N   GLY M 252      31.746 -26.594  14.226  1.00 20.08           N  
+ATOM   2136  CA  GLY M 252      31.628 -27.934  14.785  1.00 19.82           C  
+ATOM   2137  C   GLY M 252      30.693 -28.032  15.977  1.00 19.23           C  
+ATOM   2138  O   GLY M 252      30.361 -29.139  16.426  1.00 19.53           O  
+ATOM   2139  N   GLN M 253      30.259 -26.890  16.503  1.00 17.11           N  
+ATOM   2140  CA  GLN M 253      29.361 -26.911  17.664  1.00 17.77           C  
+ATOM   2141  C   GLN M 253      27.910 -26.522  17.317  1.00 16.96           C  
+ATOM   2142  O   GLN M 253      27.086 -26.266  18.206  1.00 16.22           O  
+ATOM   2143  CB  GLN M 253      29.926 -26.024  18.775  1.00 18.30           C  
+ATOM   2144  CG  GLN M 253      31.331 -26.425  19.175  1.00 19.95           C  
+ATOM   2145  CD  GLN M 253      31.424 -27.884  19.568  1.00 20.95           C  
+ATOM   2146  OE1 GLN M 253      30.625 -28.362  20.349  1.00 23.46           O  
+ATOM   2147  NE2 GLN M 253      32.417 -28.592  19.040  1.00 23.89           N  
+ATOM   2148  N   GLU M 254      27.611 -26.483  16.022  1.00 17.04           N  
+ATOM   2149  CA  GLU M 254      26.302 -26.032  15.533  1.00 18.16           C  
+ATOM   2150  C   GLU M 254      25.132 -26.800  16.167  1.00 18.62           C  
+ATOM   2151  O   GLU M 254      24.060 -26.252  16.428  1.00 16.97           O  
+ATOM   2152  CB  GLU M 254      26.249 -26.199  14.012  1.00 18.94           C  
+ATOM   2153  CG  GLU M 254      27.121 -25.249  13.257  1.00 20.28           C  
+ATOM   2154  CD  GLU M 254      28.519 -25.765  13.020  1.00 21.88           C  
+ATOM   2155  OE1 GLU M 254      28.910 -26.836  13.563  1.00 24.69           O  
+ATOM   2156  OE2 GLU M 254      29.237 -25.074  12.292  1.00 23.51           O  
+ATOM   2157  N   GLN M 255      25.352 -28.082  16.422  1.00 19.82           N  
+ATOM   2158  CA  GLN M 255      24.299 -28.954  16.934  1.00 21.35           C  
+ATOM   2159  C   GLN M 255      23.794 -28.556  18.319  1.00 20.23           C  
+ATOM   2160  O   GLN M 255      22.722 -29.006  18.735  1.00 18.97           O  
+ATOM   2161  CB  GLN M 255      24.777 -30.418  16.943  1.00 24.42           C  
+ATOM   2162  CG  GLN M 255      25.727 -30.786  15.782  1.00 30.70           C  
+ATOM   2163  CD  GLN M 255      27.122 -30.137  15.893  1.00 34.48           C  
+ATOM   2164  OE1 GLN M 255      27.514 -29.653  16.960  1.00 37.49           O  
+ATOM   2165  NE2 GLN M 255      27.872 -30.134  14.785  1.00 34.98           N  
+ATOM   2166  N   ARG M 256      24.553 -27.725  19.040  1.00 18.08           N  
+ATOM   2167  CA  ARG M 256      24.132 -27.306  20.389  1.00 18.32           C  
+ATOM   2168  C   ARG M 256      22.998 -26.290  20.364  1.00 17.78           C  
+ATOM   2169  O   ARG M 256      22.311 -26.090  21.355  1.00 16.78           O  
+ATOM   2170  CB  ARG M 256      25.296 -26.639  21.116  1.00 17.59           C  
+ATOM   2171  CG  ARG M 256      26.516 -27.492  21.278  1.00 18.58           C  
+ATOM   2172  CD  ARG M 256      27.509 -26.778  22.213  1.00 15.49           C  
+ATOM   2173  NE  ARG M 256      28.666 -27.615  22.425  1.00 19.15           N  
+ATOM   2174  CZ  ARG M 256      28.789 -28.474  23.424  1.00 16.95           C  
+ATOM   2175  NH1 ARG M 256      29.891 -29.194  23.511  1.00 20.89           N  
+ATOM   2176  NH2 ARG M 256      27.838 -28.579  24.335  1.00 17.23           N  
+ATOM   2177  N   TYR M 257      22.871 -25.611  19.225  1.00 17.38           N  
+ATOM   2178  CA  TYR M 257      22.020 -24.448  19.080  1.00 16.94           C  
+ATOM   2179  C   TYR M 257      20.689 -24.835  18.449  1.00 17.42           C  
+ATOM   2180  O   TYR M 257      20.655 -25.635  17.510  1.00 17.52           O  
+ATOM   2181  CB  TYR M 257      22.742 -23.389  18.240  1.00 17.41           C  
+ATOM   2182  CG  TYR M 257      24.013 -22.908  18.919  1.00 15.87           C  
+ATOM   2183  CD1 TYR M 257      24.012 -21.730  19.659  1.00 17.58           C  
+ATOM   2184  CD2 TYR M 257      25.194 -23.665  18.866  1.00 16.66           C  
+ATOM   2185  CE1 TYR M 257      25.148 -21.283  20.309  1.00 16.99           C  
+ATOM   2186  CE2 TYR M 257      26.364 -23.231  19.523  1.00 16.37           C  
+ATOM   2187  CZ  TYR M 257      26.330 -22.040  20.233  1.00 17.83           C  
+ATOM   2188  OH  TYR M 257      27.449 -21.584  20.900  1.00 17.26           O  
+ATOM   2189  N   THR M 258      19.602 -24.310  19.005  1.00 16.92           N  
+ATOM   2190  CA  THR M 258      18.289 -24.493  18.395  1.00 17.59           C  
+ATOM   2191  C   THR M 258      17.580 -23.162  18.198  1.00 17.02           C  
+ATOM   2192  O   THR M 258      17.655 -22.287  19.055  1.00 17.44           O  
+ATOM   2193  CB  THR M 258      17.404 -25.442  19.220  1.00 17.13           C  
+ATOM   2194  OG1 THR M 258      17.388 -25.006  20.581  1.00 18.37           O  
+ATOM   2195  CG2 THR M 258      17.963 -26.831  19.150  1.00 18.44           C  
+ATOM   2196  N   CYS M 259      16.910 -23.021  17.049  1.00 15.95           N  
+ATOM   2197  CA  CYS M 259      16.066 -21.874  16.780  1.00 16.59           C  
+ATOM   2198  C   CYS M 259      14.616 -22.221  17.154  1.00 16.74           C  
+ATOM   2199  O   CYS M 259      14.090 -23.256  16.724  1.00 17.23           O  
+ATOM   2200  CB  CYS M 259      16.127 -21.504  15.300  1.00 16.16           C  
+ATOM   2201  SG  CYS M 259      15.178 -20.021  14.951  1.00 20.82           S  
+ATOM   2202  N   HIS M 260      13.993 -21.354  17.949  1.00 16.82           N  
+ATOM   2203  CA AHIS M 260      12.618 -21.565  18.368  0.50 16.86           C  
+ATOM   2204  CA BHIS M 260      12.619 -21.542  18.423  0.50 17.21           C  
+ATOM   2205  C   HIS M 260      11.685 -20.509  17.781  1.00 16.96           C  
+ATOM   2206  O   HIS M 260      11.927 -19.307  17.872  1.00 15.08           O  
+ATOM   2207  CB AHIS M 260      12.530 -21.627  19.893  0.50 17.74           C  
+ATOM   2208  CB BHIS M 260      12.571 -21.411  19.954  0.50 18.45           C  
+ATOM   2209  CG AHIS M 260      13.350 -22.732  20.480  0.50 17.92           C  
+ATOM   2210  CG BHIS M 260      11.316 -21.940  20.579  0.50 19.87           C  
+ATOM   2211  ND1AHIS M 260      14.713 -22.631  20.658  0.50 17.80           N  
+ATOM   2212  ND1BHIS M 260      10.968 -23.276  20.545  0.50 21.57           N  
+ATOM   2213  CD2AHIS M 260      13.007 -23.974  20.895  0.50 19.23           C  
+ATOM   2214  CD2BHIS M 260      10.338 -21.316  21.279  0.50 20.52           C  
+ATOM   2215  CE1AHIS M 260      15.171 -23.756  21.171  0.50 17.49           C  
+ATOM   2216  CE1BHIS M 260       9.828 -23.448  21.187  0.50 20.90           C  
+ATOM   2217  NE2AHIS M 260      14.159 -24.589  21.324  0.50 19.40           N  
+ATOM   2218  NE2BHIS M 260       9.425 -22.275  21.643  0.50 21.73           N  
+ATOM   2219  N   VAL M 261      10.620 -20.981  17.153  1.00 17.50           N  
+ATOM   2220  CA  VAL M 261       9.698 -20.113  16.436  1.00 17.55           C  
+ATOM   2221  C   VAL M 261       8.277 -20.219  16.970  1.00 18.54           C  
+ATOM   2222  O   VAL M 261       7.690 -21.312  17.000  1.00 19.67           O  
+ATOM   2223  CB  VAL M 261       9.642 -20.475  14.950  1.00 17.68           C  
+ATOM   2224  CG1 VAL M 261       8.919 -19.375  14.197  1.00 15.64           C  
+ATOM   2225  CG2 VAL M 261      11.042 -20.717  14.366  1.00 19.07           C  
+ATOM   2226  N   GLN M 262       7.732 -19.089  17.401  1.00 19.05           N  
+ATOM   2227  CA  GLN M 262       6.369 -19.038  17.935  1.00 19.29           C  
+ATOM   2228  C   GLN M 262       5.521 -18.134  17.041  1.00 18.01           C  
+ATOM   2229  O   GLN M 262       5.897 -16.984  16.813  1.00 15.94           O  
+ATOM   2230  CB  GLN M 262       6.367 -18.472  19.360  1.00 20.04           C  
+ATOM   2231  CG  GLN M 262       7.303 -19.224  20.315  1.00 25.82           C  
+ATOM   2232  CD  GLN M 262       7.446 -18.541  21.681  1.00 28.04           C  
+ATOM   2233  OE1 GLN M 262       8.469 -17.924  21.979  1.00 27.93           O  
+ATOM   2234  NE2 GLN M 262       6.419 -18.660  22.513  1.00 30.07           N  
+ATOM   2235  N   HIS M 263       4.386 -18.659  16.575  1.00 17.55           N  
+ATOM   2236  CA  HIS M 263       3.467 -17.939  15.678  1.00 16.93           C  
+ATOM   2237  C   HIS M 263       2.066 -18.585  15.752  1.00 19.73           C  
+ATOM   2238  O   HIS M 263       1.933 -19.810  15.870  1.00 19.21           O  
+ATOM   2239  CB  HIS M 263       3.994 -17.973  14.239  1.00 15.15           C  
+ATOM   2240  CG  HIS M 263       3.278 -17.047  13.300  1.00 15.77           C  
+ATOM   2241  ND1 HIS M 263       2.212 -17.450  12.522  1.00 15.41           N  
+ATOM   2242  CD2 HIS M 263       3.494 -15.745  12.995  1.00 14.93           C  
+ATOM   2243  CE1 HIS M 263       1.804 -16.434  11.778  1.00 14.33           C  
+ATOM   2244  NE2 HIS M 263       2.554 -15.385  12.056  1.00 12.49           N  
+ATOM   2245  N   GLU M 264       1.029 -17.762  15.665  1.00 21.88           N  
+ATOM   2246  CA  GLU M 264      -0.333 -18.265  15.810  1.00 24.01           C  
+ATOM   2247  C   GLU M 264      -0.716 -19.194  14.680  1.00 23.53           C  
+ATOM   2248  O   GLU M 264      -1.628 -19.999  14.816  1.00 23.14           O  
+ATOM   2249  CB  GLU M 264      -1.348 -17.122  16.014  1.00 25.67           C  
+ATOM   2250  CG  GLU M 264      -1.621 -16.252  14.815  1.00 28.36           C  
+ATOM   2251  CD  GLU M 264      -2.816 -15.299  15.029  1.00 31.15           C  
+ATOM   2252  OE1 GLU M 264      -3.888 -15.537  14.437  1.00 33.88           O  
+ATOM   2253  OE2 GLU M 264      -2.685 -14.314  15.789  1.00 32.71           O  
+ATOM   2254  N   GLY M 265       0.019 -19.122  13.577  1.00 23.81           N  
+ATOM   2255  CA  GLY M 265      -0.173 -20.041  12.467  1.00 25.97           C  
+ATOM   2256  C   GLY M 265       0.320 -21.459  12.715  1.00 28.08           C  
+ATOM   2257  O   GLY M 265       0.051 -22.362  11.912  1.00 27.82           O  
+ATOM   2258  N   LEU M 266       1.032 -21.651  13.827  1.00 28.61           N  
+ATOM   2259  CA  LEU M 266       1.651 -22.939  14.180  1.00 30.60           C  
+ATOM   2260  C   LEU M 266       0.864 -23.630  15.290  1.00 32.43           C  
+ATOM   2261  O   LEU M 266       0.564 -23.010  16.315  1.00 33.71           O  
+ATOM   2262  CB  LEU M 266       3.103 -22.716  14.656  1.00 28.39           C  
+ATOM   2263  CG  LEU M 266       4.122 -22.229  13.618  1.00 26.91           C  
+ATOM   2264  CD1 LEU M 266       5.406 -21.695  14.275  1.00 26.71           C  
+ATOM   2265  CD2 LEU M 266       4.447 -23.304  12.604  1.00 25.07           C  
+ATOM   2266  N   PRO M 267       0.539 -24.920  15.106  1.00 34.35           N  
+ATOM   2267  CA  PRO M 267      -0.158 -25.679  16.164  1.00 35.47           C  
+ATOM   2268  C   PRO M 267       0.597 -25.603  17.501  1.00 36.14           C  
+ATOM   2269  O   PRO M 267       0.002 -25.320  18.545  1.00 37.39           O  
+ATOM   2270  CB  PRO M 267      -0.158 -27.117  15.635  1.00 35.58           C  
+ATOM   2271  CG  PRO M 267       0.050 -26.987  14.138  1.00 35.89           C  
+ATOM   2272  CD  PRO M 267       0.841 -25.734  13.914  1.00 34.62           C  
+ATOM   2273  N   LYS M 268       1.901 -25.860  17.459  1.00 34.94           N  
+ATOM   2274  CA  LYS M 268       2.780 -25.643  18.599  1.00 34.66           C  
+ATOM   2275  C   LYS M 268       4.086 -25.013  18.104  1.00 32.38           C  
+ATOM   2276  O   LYS M 268       4.404 -25.102  16.911  1.00 31.27           O  
+ATOM   2277  CB  LYS M 268       3.051 -26.966  19.330  1.00 36.00           C  
+ATOM   2278  CG  LYS M 268       2.945 -28.215  18.449  1.00 39.78           C  
+ATOM   2279  CD  LYS M 268       4.261 -28.597  17.748  1.00 41.86           C  
+ATOM   2280  CE  LYS M 268       4.604 -27.714  16.539  1.00 43.75           C  
+ATOM   2281  NZ  LYS M 268       3.455 -27.379  15.625  1.00 44.71           N  
+ATOM   2282  N   PRO M 269       4.853 -24.386  19.011  1.00 31.10           N  
+ATOM   2283  CA  PRO M 269       6.129 -23.811  18.585  1.00 30.45           C  
+ATOM   2284  C   PRO M 269       7.014 -24.819  17.840  1.00 29.66           C  
+ATOM   2285  O   PRO M 269       6.934 -26.025  18.079  1.00 28.21           O  
+ATOM   2286  CB  PRO M 269       6.784 -23.384  19.904  1.00 31.04           C  
+ATOM   2287  CG  PRO M 269       5.639 -23.137  20.828  1.00 30.64           C  
+ATOM   2288  CD  PRO M 269       4.586 -24.144  20.441  1.00 31.98           C  
+ATOM   2289  N   LEU M 270       7.820 -24.313  16.916  1.00 29.18           N  
+ATOM   2290  CA  LEU M 270       8.781 -25.127  16.186  1.00 28.75           C  
+ATOM   2291  C   LEU M 270      10.177 -24.982  16.782  1.00 28.63           C  
+ATOM   2292  O   LEU M 270      10.555 -23.920  17.265  1.00 26.27           O  
+ATOM   2293  CB  LEU M 270       8.867 -24.693  14.725  1.00 28.47           C  
+ATOM   2294  CG  LEU M 270       7.678 -24.764  13.787  1.00 29.31           C  
+ATOM   2295  CD1 LEU M 270       8.159 -24.510  12.360  1.00 30.57           C  
+ATOM   2296  CD2 LEU M 270       6.955 -26.104  13.913  1.00 29.75           C  
+ATOM   2297  N   THR M 271      10.942 -26.058  16.700  1.00 29.19           N  
+ATOM   2298  CA  THR M 271      12.321 -26.060  17.137  1.00 30.63           C  
+ATOM   2299  C   THR M 271      13.157 -26.535  15.970  1.00 30.89           C  
+ATOM   2300  O   THR M 271      12.984 -27.658  15.499  1.00 32.26           O  
+ATOM   2301  CB  THR M 271      12.531 -27.004  18.326  1.00 31.03           C  
+ATOM   2302  OG1 THR M 271      11.710 -26.579  19.417  1.00 31.19           O  
+ATOM   2303  CG2 THR M 271      14.014 -27.007  18.768  1.00 31.85           C  
+ATOM   2304  N   LEU M 272      14.047 -25.677  15.488  1.00 30.62           N  
+ATOM   2305  CA  LEU M 272      14.950 -26.039  14.404  1.00 30.85           C  
+ATOM   2306  C   LEU M 272      16.349 -26.330  14.934  1.00 30.94           C  
+ATOM   2307  O   LEU M 272      16.853 -25.620  15.795  1.00 28.75           O  
+ATOM   2308  CB  LEU M 272      15.065 -24.904  13.388  1.00 31.10           C  
+ATOM   2309  CG  LEU M 272      13.925 -24.625  12.408  1.00 33.43           C  
+ATOM   2310  CD1 LEU M 272      12.681 -24.204  13.162  1.00 32.18           C  
+ATOM   2311  CD2 LEU M 272      14.348 -23.559  11.405  1.00 31.94           C  
+ATOM   2312  N   ARG M 273      16.975 -27.370  14.396  1.00 32.57           N  
+ATOM   2313  CA  ARG M 273      18.388 -27.642  14.667  1.00 34.10           C  
+ATOM   2314  C   ARG M 273      19.098 -27.878  13.341  1.00 34.20           C  
+ATOM   2315  O   ARG M 273      18.581 -28.577  12.473  1.00 33.38           O  
+ATOM   2316  CB  ARG M 273      18.564 -28.852  15.583  1.00 34.73           C  
+ATOM   2317  CG  ARG M 273      19.978 -28.978  16.159  1.00 36.66           C  
+ATOM   2318  CD  ARG M 273      20.159 -30.271  16.944  1.00 39.11           C  
+ATOM   2319  NE  ARG M 273      19.039 -30.534  17.848  1.00 41.94           N  
+ATOM   2320  CZ  ARG M 273      19.013 -30.204  19.140  1.00 42.82           C  
+ATOM   2321  NH1 ARG M 273      20.052 -29.589  19.702  1.00 43.58           N  
+ATOM   2322  NH2 ARG M 273      17.945 -30.489  19.877  1.00 43.30           N  
+ATOM   2323  N   TRP M 274      20.263 -27.261  13.184  1.00 34.28           N  
+ATOM   2324  CA  TRP M 274      21.088 -27.423  11.990  1.00 35.45           C  
+ATOM   2325  C   TRP M 274      21.601 -28.859  11.913  1.00 36.02           C  
+ATOM   2326  O   TRP M 274      21.540 -29.503  10.861  1.00 36.28           O  
+ATOM   2327  CB  TRP M 274      22.250 -26.420  12.030  1.00 35.63           C  
+ATOM   2328  CG  TRP M 274      23.311 -26.597  10.979  1.00 37.23           C  
+ATOM   2329  CD1 TRP M 274      24.492 -27.287  11.107  1.00 37.97           C  
+ATOM   2330  CD2 TRP M 274      23.303 -26.059   9.652  1.00 37.84           C  
+ATOM   2331  NE1 TRP M 274      25.215 -27.210   9.938  1.00 38.77           N  
+ATOM   2332  CE2 TRP M 274      24.505 -26.470   9.026  1.00 38.98           C  
+ATOM   2333  CE3 TRP M 274      22.397 -25.279   8.930  1.00 38.53           C  
+ATOM   2334  CZ2 TRP M 274      24.819 -26.126   7.705  1.00 39.90           C  
+ATOM   2335  CZ3 TRP M 274      22.704 -24.938   7.617  1.00 40.53           C  
+ATOM   2336  CH2 TRP M 274      23.909 -25.360   7.017  1.00 41.16           C  
+TER    2337      TRP M 274                                                       
+ATOM   2337  N   ASN P   1     -15.226   1.284   8.267  1.00 13.73           N  
+ATOM   2338  CA  ASN P   1     -16.244   2.377   8.179  1.00 15.63           C  
+ATOM   2339  C   ASN P   1     -15.816   3.511   9.126  1.00 14.76           C  
+ATOM   2340  O   ASN P   1     -15.799   3.333  10.348  1.00 14.21           O  
+ATOM   2341  CB  ASN P   1     -17.623   1.789   8.554  1.00 17.80           C  
+ATOM   2342  CG  ASN P   1     -18.796   2.775   8.383  1.00 22.44           C  
+ATOM   2343  OD1 ASN P   1     -19.847   2.410   7.842  1.00 27.14           O  
+ATOM   2344  ND2 ASN P   1     -18.644   3.984   8.883  1.00 23.16           N  
+ATOM   2345  N   LEU P   2     -15.457   4.662   8.558  1.00 13.80           N  
+ATOM   2346  CA  LEU P   2     -14.928   5.786   9.346  1.00 13.83           C  
+ATOM   2347  C   LEU P   2     -15.986   6.384  10.255  1.00 15.13           C  
+ATOM   2348  O   LEU P   2     -17.172   6.355   9.933  1.00 13.62           O  
+ATOM   2349  CB  LEU P   2     -14.484   6.912   8.434  1.00 13.61           C  
+ATOM   2350  CG  LEU P   2     -13.278   6.786   7.515  1.00 14.32           C  
+ATOM   2351  CD1 LEU P   2     -13.347   7.933   6.546  1.00 14.71           C  
+ATOM   2352  CD2 LEU P   2     -11.988   6.865   8.334  1.00 12.54           C  
+ATOM   2353  N   VAL P   3     -15.558   6.995  11.353  1.00 16.30           N  
+ATOM   2354  CA  VAL P   3     -16.507   7.747  12.164  1.00 19.28           C  
+ATOM   2355  C   VAL P   3     -16.490   9.169  11.606  1.00 21.84           C  
+ATOM   2356  O   VAL P   3     -15.466   9.639  11.134  1.00 22.29           O  
+ATOM   2357  CB  VAL P   3     -16.140   7.737  13.679  1.00 19.26           C  
+ATOM   2358  CG1 VAL P   3     -14.881   8.540  13.953  1.00 21.04           C  
+ATOM   2359  CG2 VAL P   3     -17.297   8.252  14.542  1.00 21.15           C  
+ATOM   2360  N   PRO P   4     -17.625   9.851  11.639  1.00 25.15           N  
+ATOM   2361  CA  PRO P   4     -17.555  11.296  11.370  1.00 28.16           C  
+ATOM   2362  C   PRO P   4     -16.642  12.016  12.386  1.00 29.72           C  
+ATOM   2363  O   PRO P   4     -16.797  11.832  13.597  1.00 30.27           O  
+ATOM   2364  CB  PRO P   4     -19.016  11.737  11.516  1.00 27.54           C  
+ATOM   2365  CG  PRO P   4     -19.812  10.490  11.166  1.00 27.10           C  
+ATOM   2366  CD  PRO P   4     -19.011   9.357  11.737  1.00 25.91           C  
+ATOM   2367  N   MET P   5     -15.684  12.810  11.903  1.00 31.44           N  
+ATOM   2368  CA  MET P   5     -14.703  13.447  12.803  1.00 33.08           C  
+ATOM   2369  C   MET P   5     -14.724  14.963  12.687  1.00 32.96           C  
+ATOM   2370  O   MET P   5     -13.879  15.555  12.004  1.00 33.42           O  
+ATOM   2371  CB  MET P   5     -13.285  12.927  12.530  1.00 34.25           C  
+ATOM   2372  CG  MET P   5     -12.275  13.275  13.615  1.00 36.86           C  
+ATOM   2373  SD  MET P   5     -12.454  12.250  15.100  1.00 41.47           S  
+ATOM   2374  CE  MET P   5     -12.041  10.644  14.439  1.00 39.65           C  
+ATOM   2375  N   CYS P   6     -15.687  15.567  13.376  1.00 31.88           N  
+ATOM   2376  CA ACYS P   6     -15.975  16.998  13.326  0.50 31.79           C  
+ATOM   2377  CA BCYS P   6     -15.892  17.009  13.282  0.50 31.73           C  
+ATOM   2378  C   CYS P   6     -15.307  17.786  14.464  1.00 30.62           C  
+ATOM   2379  O   CYS P   6     -15.151  19.006  14.377  1.00 30.31           O  
+ATOM   2380  CB ACYS P   6     -17.490  17.184  13.438  0.50 31.95           C  
+ATOM   2381  CB BCYS P   6     -17.379  17.325  13.169  0.50 32.10           C  
+ATOM   2382  SG ACYS P   6     -18.405  15.612  13.573  0.50 36.55           S  
+ATOM   2383  SG BCYS P   6     -18.218  17.162  14.733  0.50 35.86           S  
+ATOM   2384  N   ALA P   7     -14.978  17.095  15.559  1.00 27.90           N  
+ATOM   2385  CA  ALA P   7     -14.396  17.770  16.724  1.00 25.88           C  
+ATOM   2386  C   ALA P   7     -12.948  18.214  16.474  1.00 23.83           C  
+ATOM   2387  O   ALA P   7     -12.081  17.398  16.185  1.00 23.82           O  
+ATOM   2388  CB  ALA P   7     -14.485  16.888  17.973  1.00 26.41           C  
+ATOM   2389  N   THR P   8     -12.707  19.517  16.581  1.00 20.87           N  
+ATOM   2390  CA  THR P   8     -11.381  20.086  16.346  1.00 19.11           C  
+ATOM   2391  C   THR P   8     -10.730  20.264  17.704  1.00 18.24           C  
+ATOM   2392  O   THR P   8     -11.425  20.383  18.703  1.00 16.69           O  
+ATOM   2393  CB  THR P   8     -11.487  21.453  15.641  1.00 20.04           C  
+ATOM   2394  OG1 THR P   8     -12.376  22.299  16.394  1.00 19.40           O  
+ATOM   2395  CG2 THR P   8     -12.058  21.286  14.223  1.00 18.11           C  
+ATOM   2396  N   VAL P   9      -9.402  20.289  17.751  1.00 17.82           N  
+ATOM   2397  CA  VAL P   9      -8.707  20.438  19.031  1.00 17.75           C  
+ATOM   2398  C   VAL P   9      -8.802  21.856  19.597  1.00 18.29           C  
+ATOM   2399  O   VAL P   9      -8.494  22.093  20.776  1.00 18.24           O  
+ATOM   2400  CB  VAL P   9      -7.225  20.047  18.917  1.00 17.27           C  
+ATOM   2401  CG1 VAL P   9      -7.105  18.602  18.470  1.00 14.68           C  
+ATOM   2402  CG2 VAL P   9      -6.476  21.009  17.976  1.00 17.64           C  
+ATOM   2403  OXT VAL P   9      -9.154  22.801  18.882  1.00 17.61           O  
+TER    2404      VAL P   9                                                       
+END   

--- a/tests/models/test_query.py
+++ b/tests/models/test_query.py
@@ -44,6 +44,12 @@ def _check_graph_makes_sense(g, node_feature_names, edge_feature_names):
     assert len(g.edges) > 0, "no edges"
     assert FEATURENAME_EDGEDISTANCE in g.edges[0].features
 
+    for edge in g.edges:
+        if edge.id.item1 == edge.id.item2:
+            raise ValueError(f"an edge pairs {edge.id.item1} with itself")
+
+    assert not g.has_nan()
+
     f, tmp_path = mkstemp(suffix=".hdf5")
     os.close(f)
 
@@ -289,3 +295,13 @@ def test_variant_residue_graph_101M():
         ],
         [FEATURENAME_EDGEDISTANCE],
     )
+
+
+def test_res_ppi():
+
+    query = ProteinProteinInterfaceResidueQuery("tests/data/pdb/3MRC/3MRC.pdb",
+                                                "M", "P")
+
+    g = query.build_graph([sasa, atomic_contact])
+
+    _check_graph_makes_sense(g, [FEATURENAME_SASA], [FEATURENAME_EDGECOULOMB])


### PR DESCRIPTION
The method **build_residue_graph** has been adapted so that no more edges can be created between a residue and itself.

The query test now tests for this error.