### PR TITLE
NeuralNet class alignment to high-level frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,13 +246,13 @@ metrics_output_directory = "./metrics"
 metrics_exporters = [OutputExporter(metrics_output_directory)]
 
 nn = Trainer(
-    GINet,
     dataset_train,
     dataset_val,
     dataset_test,
+    GINet,
     lr = 0.001,
-    batch_size = 64,
     task = "class",
+    batch_size = 64,
     metrics_exporters = metrics_exporters
 )
 
@@ -271,7 +271,7 @@ Then the Trainer can be trained and tested, and the model can be saved:
 
 ```python
 nn.train(nepoch = 50, validate = True)
-nn.test(dataset_test = dataset_test)
+nn.test()
 nn.save_model(filename = "<output_model_path.pth.tar>")
 
 ```
@@ -314,12 +314,12 @@ class CustomNet(torch.nn.Module):
         return F.log_softmax(self.fc2(x), dim=1)
 
 nn = Trainer(
-    CustomNet,
     dataset_train,
     dataset_val,
     dataset_test,
-    batch_size = 64
+    CustomNet,
     task = "class",
+    batch_size = 64,
     metrics_exporters = metrics_exporters
 )
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ from deeprankcore.models.metrics import OutputExporter, ScatterPlotExporter
 metrics_output_directory = "./metrics"
 metrics_exporters = [OutputExporter(metrics_output_directory)]
 
-nn = Trainer(
+trainer = Trainer(
     dataset_train,
     dataset_val,
     dataset_test,
@@ -263,16 +263,16 @@ Optimizer (`torch.optim.Adam` by default) and loss function can be defined by us
 ```python
 import torch
 
-nn.configure_optimizers(torch.optim.Adamax, lr = 0.001, weight_decay = 1e-04)
+trainer.configure_optimizers(torch.optim.Adamax, lr = 0.001, weight_decay = 1e-04)
 
 ```
 
 Then the Trainer can be trained and tested, and the model can be saved:
 
 ```python
-nn.train(nepoch = 50, validate = True)
-nn.test()
-nn.save_model(filename = "<output_model_path.pth.tar>")
+trainer.train(nepoch = 50, validate = True)
+trainer.test()
+trainer.save_model(filename = "<output_model_path.pth.tar>")
 
 ```
 
@@ -313,7 +313,7 @@ class CustomNet(torch.nn.Module):
         x = F.dropout(x, training=self.training)
         return F.log_softmax(self.fc2(x), dim=1)
 
-nn = Trainer(
+trainer = Trainer(
     dataset_train,
     dataset_val,
     dataset_test,
@@ -323,7 +323,7 @@ nn = Trainer(
     metrics_exporters = metrics_exporters
 )
 
-nn.train(nepoch=50)
+trainer.train(nepoch=50)
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -238,14 +238,14 @@ dataset_test = HDF5DataSet(
 Let's define a Trainer instance, using for example of the already existing GNNs, GINet:
 
 ```python
-from deeprankcore.NeuralNet import NeuralNet
+from deeprankcore.Trainer import Trainer
 from deeprankcore.ginet import GINet
 from deeprankcore.models.metrics import OutputExporter, ScatterPlotExporter
 
 metrics_output_directory = "./metrics"
 metrics_exporters = [OutputExporter(metrics_output_directory)]
 
-nn = NeuralNet(
+nn = Trainer(
     GINet,
     dataset_train,
     dataset_val,
@@ -313,7 +313,7 @@ class CustomNet(torch.nn.Module):
         x = F.dropout(x, training=self.training)
         return F.log_softmax(self.fc2(x), dim=1)
 
-nn = NeuralNet(
+nn = Trainer(
     CustomNet,
     dataset_train,
     dataset_val,

--- a/deeprankcore/DataSet.py
+++ b/deeprankcore/DataSet.py
@@ -53,53 +53,6 @@ def save_hdf5_keys(
                 f_dest[key] = h5py.ExternalLink(f_src_path, "/" + key)
 
 
-def _DivideDataSet(dataset, val_size=None):
-    """Divides the dataset into a training set and an evaluation set
-
-    Args:
-        dataset (HDF5DataSet): input dataset to be split into training and validation data
-        val_size (float or int, optional): fraction of dataset (if float) or number of datapoints (if int) to use for validation. 
-            Defaults to 0.25.
-
-    Returns:
-        HDF5DataSet: [description]
-    """
-
-    if val_size is None:
-        val_size = 0.25
-    full_size = len(dataset)
-
-    # find number of datapoints to include in training dataset
-    if isinstance (val_size, float):
-        n_val = int(val_size * full_size)
-    elif isinstance (val_size, int):
-        n_val = val_size
-    else:
-        raise TypeError (f"type(val_size) must be float, int or None ({type(val_size)} detected.)")
-    
-    # raise exception if no training data or negative validation size
-    if n_val >= full_size or n_val < 0:
-        raise ValueError ("invalid val_size. \n\t" +
-            f"val_size must be a float between 0 and 1 OR an int smaller than the size of the dataset used ({full_size})")
-
-    if val_size == 0:
-        dataset_train = dataset
-        dataset_val = None
-    else:
-        index = np.arange(full_size)
-        np.random.shuffle(index)
-
-        index_train, index_val = index[n_val:], index[:n_val]
-
-        dataset_train = copy.deepcopy(dataset)
-        dataset_train.index_complexes = [dataset.index_complexes[i] for i in index_train]
-
-        dataset_val = copy.deepcopy(dataset)
-        dataset_val.index_complexes = [dataset.index_complexes[i] for i in index_val]
-
-    return dataset_train, dataset_val
-
-
 class HDF5DataSet(Dataset):
     def __init__( # pylint: disable=too-many-arguments
         self,

--- a/deeprankcore/DataSet.py
+++ b/deeprankcore/DataSet.py
@@ -163,7 +163,7 @@ class HDF5DataSet(Dataset):
         """
 
         fname, mol = self.index_complexes[index]
-        data = self._load_one_graph(fname, mol)
+        data = self.load_one_graph(fname, mol)
         return data
 
     def _check_hdf5_files(self):

--- a/deeprankcore/DataSet.py
+++ b/deeprankcore/DataSet.py
@@ -96,7 +96,7 @@ def _DivideDataSet(dataset, val_size=None):
     return dataset_train, dataset_val
 
 
-def PreCluster(dataset, method):
+def _PreCluster(dataset, method):
     """Pre-clusters nodes of the graphs
 
     Args:
@@ -105,7 +105,7 @@ def PreCluster(dataset, method):
     """
     for fname, mol in tqdm(dataset.index_complexes):
 
-        data = dataset.load_one_graph(fname, mol)
+        data = dataset._load_one_graph(fname, mol)
 
         if data is None:
             f5 = h5py.File(fname, "a")
@@ -226,16 +226,16 @@ class HDF5DataSet(Dataset):
         self.clustering_method = clustering_method
 
         # check if the files are ok
-        self.check_hdf5_files()
+        self._check_hdf5_files()
 
         # check the selection of features
-        self.check_node_feature()
-        self.check_edge_feature()
+        self._check_node_feature()
+        self._check_edge_feature()
 
         # create the indexing system
         # alows to associate each mol to an index
         # and get fname and mol name from the index
-        self.create_index_molecules()
+        self._create_index_molecules()
 
         # get the device
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -263,10 +263,10 @@ class HDF5DataSet(Dataset):
         """
 
         fname, mol = self.index_complexes[index]
-        data = self.load_one_graph(fname, mol)
+        data = self._load_one_graph(fname, mol)
         return data
 
-    def check_hdf5_files(self):
+    def _check_hdf5_files(self):
         """Checks if the data contained in the hdf5 file is valid."""
         print("\nChecking dataset Integrity...\n")
         remove_file = []
@@ -286,7 +286,7 @@ class HDF5DataSet(Dataset):
         for name in remove_file:
             self.hdf5_path.remove(name)
 
-    def check_node_feature(self):
+    def _check_node_feature(self):
         """Checks if the required node features exist"""
         f = h5py.File(self.hdf5_path[0], "r")
         mol_key = list(f.keys())[0]
@@ -303,7 +303,7 @@ class HDF5DataSet(Dataset):
                     print(f"\nPossible node features: {self.available_node_feature}\n")
                     sys.exit()
 
-    def check_edge_feature(self):
+    def _check_edge_feature(self):
         """Checks if the required edge features exist"""
         f = h5py.File(self.hdf5_path[0], "r")
         mol_key = list(f.keys())[0]
@@ -320,7 +320,7 @@ class HDF5DataSet(Dataset):
                     print(f"\nPossible edge features: {self.available_edge_feature}\n")
                     sys.exit()
 
-    def load_one_graph(self, fname, mol): # noqa
+    def _load_one_graph(self, fname, mol): # noqa
         """Loads one graph
 
         Args:
@@ -440,7 +440,7 @@ class HDF5DataSet(Dataset):
 
         return data
 
-    def create_index_molecules(self):
+    def _create_index_molecules(self):
         """Creates the indexing of each molecule in the dataset.
 
         Creates the indexing: [ ('1ak4.hdf5,1AK4_100w),...,('1fqj.hdf5,1FGJ_400w)]
@@ -469,13 +469,13 @@ class HDF5DataSet(Dataset):
                     mol_names = [i for i in self.subset if i in list(fh5.keys())]
 
                 for k in mol_names:
-                    if self.filter(fh5[k]):
+                    if self._filter(fh5[k]):
                         self.index_complexes += [(fdata, k)]
                 fh5.close()
             except Exception:
                 _log.exception(f"on {fdata}")
 
-    def filter(self, molgrp):
+    def _filter(self, molgrp):
         """Filters the molecule according to a dictionary.
 
         The filter is based on the attribute self.dict_filter

--- a/deeprankcore/DataSet.py
+++ b/deeprankcore/DataSet.py
@@ -386,12 +386,12 @@ class HDF5DataSet(Dataset):
                 y = None
             else:
                 if "score" in grp and self.target in grp["score"]:
-                    grp['score/'+self.target][()]
                     try:
                         y = torch.tensor([grp['score/'+self.target][()]], dtype=torch.float).contiguous().to(self.device)
                     except Exception as e:
                         print(e)
-                        print('If your target variable contains categorical classes, please convert them into class indices before defining the HDF5DataSet instance.')
+                        print('If your target variable contains categorical classes, \
+                        please convert them into class indices before defining the HDF5DataSet instance.')
                 else:
 
                     possible_targets = grp["score"].keys()

--- a/deeprankcore/DataSet.py
+++ b/deeprankcore/DataSet.py
@@ -179,7 +179,11 @@ class HDF5DataSet(Dataset):
             dict_filter (dictionary, optional): Dictionary of type [name: cond] to filter the molecules.
             Defaults to None.
 
-            target (str, optional): irmsd, lrmsd, fnat, bin, capri_class or DockQ. Defaults to None.
+            target (str, optional): irmsd, lrmsd, fnat, bin, capri_class or DockQ. It can also be a custom-defined
+            target given to the Query class as input (see: deeprankcore.models.query); in the latter case, specify
+            here its name. Only numerical target variables are supported, not categorical. If the latter is your case,
+            please convert the categorical classes into numerical class indices before defining the HDF5DataSet instance.
+            Defaults to None.
 
             tqdm (bool, optional): Show progress bar. Defaults to True.
 
@@ -382,7 +386,12 @@ class HDF5DataSet(Dataset):
                 y = None
             else:
                 if "score" in grp and self.target in grp["score"]:
-                    y = torch.tensor([grp['score/'+self.target][()]], dtype=torch.float).contiguous().to(self.device)
+                    grp['score/'+self.target][()]
+                    try:
+                        y = torch.tensor([grp['score/'+self.target][()]], dtype=torch.float).contiguous().to(self.device)
+                    except Exception as e:
+                        print(e)
+                        print('If your target variable contains categorical classes, please convert them into class indices before defining the HDF5DataSet instance.')
                 else:
 
                     possible_targets = grp["score"].keys()

--- a/deeprankcore/DataSet.py
+++ b/deeprankcore/DataSet.py
@@ -1,21 +1,17 @@
 import sys
 import os
-
 import logging
 import warnings
-
 import torch
 import numpy as np
 from torch_geometric.data.dataset import Dataset
 from torch_geometric.data.data import Data
 from tqdm import tqdm
 import h5py
-import copy
 from ast import literal_eval
 from typing import Callable
 from typing import List
 from typing import Union
-
 
 _log = logging.getLogger(__name__)
 
@@ -157,12 +153,6 @@ class HDF5DataSet(Dataset):
         """
         return len(self.index_complexes)
 
-    def _download(self):
-        pass
-
-    def _process(self):
-        pass
-
     def get(self, index): # pylint: disable=arguments-renamed
         """Gets one item from its unique index.
 
@@ -230,7 +220,7 @@ class HDF5DataSet(Dataset):
                     print(f"\nPossible edge features: {self.available_edge_feature}\n")
                     sys.exit()
 
-    def _load_one_graph(self, fname, mol): # noqa
+    def load_one_graph(self, fname, mol): # noqa
         """Loads one graph
 
         Args:

--- a/deeprankcore/DataSet.py
+++ b/deeprankcore/DataSet.py
@@ -83,15 +83,20 @@ def _DivideDataSet(dataset, val_size=None):
         raise ValueError ("invalid val_size. \n\t" +
             f"val_size must be a float between 0 and 1 OR an int smaller than the size of the dataset used ({full_size})")
 
-    index = np.arange(full_size)
-    np.random.shuffle(index)
-    index_train, index_val = index[n_val:], index[:n_val]
+    if val_size == 0:
+        dataset_train = dataset
+        dataset_val = None
+    else:
+        index = np.arange(full_size)
+        np.random.shuffle(index)
 
-    dataset_train = copy.deepcopy(dataset)
-    dataset_train.index_complexes = [dataset.index_complexes[i] for i in index_train]
+        index_train, index_val = index[n_val:], index[:n_val]
 
-    dataset_val = copy.deepcopy(dataset)
-    dataset_val.index_complexes = [dataset.index_complexes[i] for i in index_val]
+        dataset_train = copy.deepcopy(dataset)
+        dataset_train.index_complexes = [dataset.index_complexes[i] for i in index_train]
+
+        dataset_val = copy.deepcopy(dataset)
+        dataset_val.index_complexes = [dataset.index_complexes[i] for i in index_val]
 
     return dataset_train, dataset_val
 

--- a/deeprankcore/Trainer.py
+++ b/deeprankcore/Trainer.py
@@ -16,7 +16,7 @@ from deeprankcore.DataSet import _DivideDataSet, PreCluster
 _log = logging.getLogger(__name__)
 
 
-class NeuralNet():
+class Trainer():
 
     def __init__(self, # pylint: disable=too-many-arguments
                  Net,
@@ -37,7 +37,7 @@ class NeuralNet():
         Args:
             Net (function, required): neural network class (ex. GINet, Foutnet etc.).
                 It should subclass torch.nn.Module, and it shouldn't be specific to regression or classification
-                in terms of output shape (NeuralNet class takes care of formatting the output shape according to the task).
+                in terms of output shape (Trainer class takes care of formatting the output shape according to the task).
                 More specifically, in classification task cases, softmax shouldn't be used as the last activation function.
             dataset_train (HDF5DataSet object, required): training set used during training.
             dataset_val (HDF5DataSet object, optional): evaluation set used during training.
@@ -96,7 +96,7 @@ class NeuralNet():
                         "User target detected -> The task argument is required ('class' or 'reg'). \n\t"
                         "Example: \n\t"
                         ""
-                        "model = NeuralNet(dataset, GINet,"
+                        "model = Trainer(dataset, GINet,"
                         "                  target='physiological_assembly',"
                         "                  task='class',"
                         "                  val_size=0.25)")
@@ -412,7 +412,7 @@ class NeuralNet():
                         "\n\t"
                         ">> model.test(test_dataset)\n\t"
                         "if a pretrained network is loaded, you can directly test the model on the loaded dataset :\n\t"
-                        ">> model = NeuralNet(dataset_test, gnn, pretrained_model = model_saved, target=None)\n\t"
+                        ">> model = Trainer(dataset_test, gnn, pretrained_model = model_saved, target=None)\n\t"
                         ">> model.test()\n\t")
 
             # Run test

--- a/deeprankcore/Trainer.py
+++ b/deeprankcore/Trainer.py
@@ -303,6 +303,9 @@ class Trainer():
         # classification mode
         elif self.task == "class":
 
+            self.classes_to_idx = {
+                i: idx for idx, i in enumerate(self.classes)
+            }
             self.output_shape = len(self.classes)
 
             self.model = Net(
@@ -598,12 +601,8 @@ class Trainer():
         if (self.task == 'class') and (target is not None):
             # For categorical cross entropy, the target must be a one-dimensional tensor
             # of class indices with type long and the output should have raw, unnormalized values
-            classes_to_idx = {
-                i: idx for idx, i in enumerate(self.classes)
-            }
-
             target = torch.tensor(
-                [classes_to_idx[int(x)] for x in target]
+                [self.classes_to_idx[int(x)] for x in target]
             ).to(self.device)
 
         elif self.task == 'reg':

--- a/deeprankcore/Trainer.py
+++ b/deeprankcore/Trainer.py
@@ -11,7 +11,7 @@ from torch_geometric.loader import DataLoader
 
 # deeprankcore import
 from deeprankcore.models.metrics import MetricsExporterCollection, MetricsExporter
-from deeprankcore.DataSet import _DivideDataSet, PreCluster
+from deeprankcore.DataSet import _DivideDataSet, _PreCluster
 
 _log = logging.getLogger(__name__)
 
@@ -154,7 +154,7 @@ class Trainer():
         self.test_loader = DataLoader(dataset_test)
 
         if self.cluster_nodes is not None: 
-            PreCluster(dataset_test, method=self.cluster_nodes)
+            _PreCluster(dataset_test, method=self.cluster_nodes)
 
         print("Test set loaded")
         
@@ -185,10 +185,10 @@ class Trainer():
         if self.cluster_nodes is not None:
             if self.cluster_nodes in ('mcl', 'louvain'):
                 print("Loading clusters")
-                PreCluster(dataset_train, method=self.cluster_nodes)
+                _PreCluster(dataset_train, method=self.cluster_nodes)
 
                 if dataset_val is not None:
-                    PreCluster(dataset_val, method=self.cluster_nodes)
+                    _PreCluster(dataset_val, method=self.cluster_nodes)
                 else:
                     print("No validation dataset given. Randomly splitting training set in training set and validation set.")
                     dataset_train, dataset_val = _DivideDataSet(
@@ -215,7 +215,7 @@ class Trainer():
 
             if self.cluster_nodes in ('mcl', 'louvain'):
                 print("Loading clusters for the evaluation set.")
-                PreCluster(dataset_test, method=self.cluster_nodes)
+                _PreCluster(dataset_test, method=self.cluster_nodes)
 
             self.valid_loader = DataLoader(
                 dataset_test, batch_size=self.batch_size, shuffle=self.shuffle
@@ -401,7 +401,7 @@ class Trainer():
             # Loads the test dataset if provided
             if dataset_test is not None:
 
-                PreCluster(dataset_test, method='mcl')
+                _PreCluster(dataset_test, method='mcl')
 
                 self.test_loader = DataLoader(dataset_test)
 

--- a/deeprankcore/Trainer.py
+++ b/deeprankcore/Trainer.py
@@ -376,6 +376,8 @@ class Trainer():
 
             self._eval(self.train_loader, 0, "training")
             if validate:
+                if self.valid_loader is None:
+                    raise ValueError("No validation dataset provided.")
                 self._eval(self.valid_loader, 0, "validation")
 
             # Loop over epochs
@@ -390,9 +392,6 @@ class Trainer():
 
                 # Validate the model
                 if validate:
-
-                    if self.valid_loader is None:
-                        raise ValueError("No validation dataset provided.")
 
                     loss_ = self._eval(self.valid_loader, epoch, "validation")
 

--- a/deeprankcore/Trainer.py
+++ b/deeprankcore/Trainer.py
@@ -689,7 +689,7 @@ class Trainer():
         """
         for fname, mol in tqdm(dataset.index_complexes):
 
-            data = dataset._load_one_graph(fname, mol)
+            data = dataset.load_one_graph(fname, mol)
 
             if data is None:
                 f5 = h5py.File(fname, "a")

--- a/deeprankcore/models/query.py
+++ b/deeprankcore/models/query.py
@@ -29,7 +29,7 @@ class Query:
     The get_all_scores function under deeprankcore.tools.score is a nice way to get started. It will output a directory that can serve
     as input for the targets argument.
 
-    Currently, the NeuralNet class under deeprankcore.NeuralNet can work with target values, that have one of the following names:
+    Currently, the Trainer class under deeprankcore.Trainer can work with target values, that have one of the following names:
 
       for classification:
        - bin_class (scalar value is expected to be either 0 or 1)
@@ -41,7 +41,7 @@ class Query:
        - fnat
        - dockQ
 
-    Other target names are also allowed, but require additional settings to the NeuralNet object.
+    Other target names are also allowed, but require additional settings to the Trainer object.
     """
 
     def __init__(self, model_id: str, targets: Optional[Dict[str, Union[float, int]]] = None):

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -111,7 +111,7 @@ from deeprankcore.models.metrics import OutputExporter, ScatterPlotExporter
 metrics_output_directory = "./metrics"
 metrics_exporters = [OutputExporter(metrics_output_directory)]
 
-nn = Trainer(
+trainer = Trainer(
     dataset_train,
     dataset_val,
     dataset_test,
@@ -122,9 +122,9 @@ nn = Trainer(
     metrics_exporters = metrics_exporters
 )
 
-nn.train(nepoch = 50, validate = True)
-nn.test()
-nn.save_model(filename = "<output_model_path.pth.tar>")
+trainer.train(nepoch = 50, validate = True)
+trainer.test()
+trainer.save_model(filename = "<output_model_path.pth.tar>")
 ```
 
 
@@ -166,7 +166,7 @@ class CustomNet(torch.nn.Module):
         return F.log_softmax(self.fc2(x), dim=1)
 
 
-nn = Trainer(
+trainer = Trainer(
     dataset_train,
     dataset_val,
     dataset_test,
@@ -176,8 +176,8 @@ nn = Trainer(
     metrics_exporters = metrics_exporters
 )
 
-nn.configure_optimizers(torch.optim.Adamax, lr = 0.001, weight_decay = 1e-04)
-nn.train(nepoch=50)
+trainer.configure_optimizers(torch.optim.Adamax, lr = 0.001, weight_decay = 1e-04)
+trainer.train(nepoch=50)
 ```
 
 ## h5x support

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -104,14 +104,14 @@ dataset_test = HDF5DataSet(
 Training can be performed using one of the already existing GNNs, for example GINet:
 
 ```python
-from deeprankcore.NeuralNet import NeuralNet
+from deeprankcore.Trainer import Trainer
 from deeprankcore.ginet import GINet
 from deeprankcore.models.metrics import OutputExporter, ScatterPlotExporter
 
 metrics_output_directory = "./metrics"
 metrics_exporters = [OutputExporter(metrics_output_directory)]
 
-nn = NeuralNet(
+nn = Trainer(
     GINet,
     dataset_train,
     dataset_val,
@@ -166,7 +166,7 @@ class CustomNet(torch.nn.Module):
         return F.log_softmax(self.fc2(x), dim=1)
 
 
-nn = NeuralNet(
+nn = Trainer(
     CustomNet,
     dataset_train,
     dataset_val,

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -112,18 +112,18 @@ metrics_output_directory = "./metrics"
 metrics_exporters = [OutputExporter(metrics_output_directory)]
 
 nn = Trainer(
-    GINet,
     dataset_train,
     dataset_val,
     dataset_test,
+    GINet,
     lr = 0.001,
-    batch_size = 64,
     task = "class",
+    batch_size = 64,
     metrics_exporters = metrics_exporters
 )
 
 nn.train(nepoch = 50, validate = True)
-nn.test(dataset_test = dataset_test)
+nn.test()
 nn.save_model(filename = "<output_model_path.pth.tar>")
 ```
 
@@ -167,12 +167,12 @@ class CustomNet(torch.nn.Module):
 
 
 nn = Trainer(
-    CustomNet,
     dataset_train,
     dataset_val,
     dataset_test,
-    batch_size = 64
+    CustomNet,
     task = "class",
+    batch_size = 64,
     metrics_exporters = metrics_exporters
 )
 

--- a/docs/reference/deeprankcore.rst
+++ b/docs/reference/deeprankcore.rst
@@ -40,10 +40,10 @@ deeprankcore.Metrics module
    :undoc-members:
    :show-inheritance:
 
-deeprankcore.NeuralNet module
+deeprankcore.Trainer module
 -----------------------------
 
-.. automodule:: deeprankcore.NeuralNet
+.. automodule:: deeprankcore.Trainer
    :members:
    :undoc-members:
    :show-inheritance:

--- a/example/nn.py
+++ b/example/nn.py
@@ -1,4 +1,4 @@
-from deeprankcore.NeuralNet import NeuralNet
+from deeprankcore.Trainer import Trainer
 from deeprankcore.DataSet import HDF5DataSet
 from deeprankcore.ginet import GINet
 
@@ -14,7 +14,7 @@ dataset = HDF5DataSet(
     clustering_method='mcl',
 )
 
-NN = NeuralNet(
+NN = Trainer(
     dataset,
     GINet,
     task="reg",

--- a/example/nn.py
+++ b/example/nn.py
@@ -14,13 +14,13 @@ dataset = HDF5DataSet(
     clustering_method='mcl',
 )
 
-NN = Trainer(
+nn = Trainer(
     dataset,
     GINet,
+    val_size=0.25,
     task="reg",
     batch_size=64,
-    val_size=0.25
 )
 
-NN.train(nepoch=250, validate=False)
-NN.plot_scatter()
+nn.train(nepoch=250, validate=False)
+nn.plot_scatter()

--- a/example/nn.py
+++ b/example/nn.py
@@ -14,7 +14,7 @@ dataset = HDF5DataSet(
     clustering_method='mcl',
 )
 
-nn = Trainer(
+trainer = Trainer(
     dataset,
     GINet,
     val_size=0.25,
@@ -22,5 +22,5 @@ nn = Trainer(
     batch_size=64,
 )
 
-nn.train(nepoch=250, validate=False)
-nn.plot_scatter()
+trainer.train(nepoch=250, validate=False)
+trainer.plot_scatter()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,5 +1,6 @@
 import unittest
-from deeprankcore.DataSet import HDF5DataSet, save_hdf5_keys, _DivideDataSet
+from deeprankcore.DataSet import HDF5DataSet, save_hdf5_keys
+from deeprankcore.Trainer import _DivideDataSet
 from torch_geometric.data.data import Data
 import h5py
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -92,7 +92,7 @@ def test_integration(): # pylint: disable=too-many-locals
             clustering_method = "mcl",
         )
 
-        nn = Trainer(
+        trainer = Trainer(
             dataset_train,
             dataset_val,
             dataset_test,
@@ -103,9 +103,9 @@ def test_integration(): # pylint: disable=too-many-locals
             transform_sigmoid=True,
         )   
 
-        nn.train(nepoch=10, validate=True) 
+        trainer.train(nepoch=10, validate=True) 
 
-        nn.save_model("test.pth.tar")
+        trainer.save_model("test.pth.tar")
 
         Trainer(dataset_train, dataset_val, dataset_test, GINet, pretrained_model="test.pth.tar")
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,7 +7,7 @@ from deeprankcore.models.query import ProteinProteinInterfaceResidueQuery
 from deeprankcore.feature import amino_acid, atomic_contact, biopython, bsa, pssm, sasa 
 from tests.utils import PATH_TEST
 from deeprankcore.DataSet import HDF5DataSet
-from deeprankcore.NeuralNet import NeuralNet
+from deeprankcore.Trainer import Trainer
 from deeprankcore.ginet import GINet
 from deeprankcore.models.metrics import OutputExporter
 from deeprankcore.tools.score import get_all_scores
@@ -92,7 +92,7 @@ def test_integration(): # pylint: disable=too-many-locals
             clustering_method = "mcl",
         )
 
-        nn = NeuralNet(
+        nn = Trainer(
             GINet,
             dataset_train,
             dataset_val,
@@ -107,7 +107,7 @@ def test_integration(): # pylint: disable=too-many-locals
 
         nn.save_model("test.pth.tar")
 
-        NeuralNet(GINet, dataset_train, dataset_val, dataset_test, pretrained_model="test.pth.tar")
+        Trainer(GINet, dataset_train, dataset_val, dataset_test, pretrained_model="test.pth.tar")
 
         assert len(os.listdir(metrics_directory)) > 0
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -93,10 +93,10 @@ def test_integration(): # pylint: disable=too-many-locals
         )
 
         nn = Trainer(
-            GINet,
             dataset_train,
             dataset_val,
             dataset_test,
+            GINet,
             task="class",
             batch_size=64,
             metrics_exporters=[OutputExporter(metrics_directory)],
@@ -107,7 +107,7 @@ def test_integration(): # pylint: disable=too-many-locals
 
         nn.save_model("test.pth.tar")
 
-        Trainer(GINet, dataset_train, dataset_val, dataset_test, pretrained_model="test.pth.tar")
+        Trainer(dataset_train, dataset_val, dataset_test, GINet, pretrained_model="test.pth.tar")
 
         assert len(os.listdir(metrics_directory)) > 0
 

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -343,7 +343,7 @@ class TestTrainer(unittest.TestCase):
         )
 
         assert len(trainer.train_loader) == len(dataset)
-        assert trainer.valid_loader == None
+        assert trainer.valid_loader is None
 
     def test_optim(self):
 

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -22,10 +22,10 @@ _log = logging.getLogger(__name__)
 
 
 def _model_base_test( # pylint: disable=too-many-arguments, too-many-locals
-    model_class,
     train_hdf5_path,
     val_hdf5_path,
     test_hdf5_path,
+    model_class,
     node_features,
     edge_features,
     task,
@@ -66,10 +66,10 @@ def _model_base_test( # pylint: disable=too-many-arguments, too-many-locals
         dataset_test = None
 
     nn = Trainer(
-        model_class,
         dataset_train,
         dataset_val,
         dataset_test,
+        model_class,
         task=task,
         batch_size=64,
         metrics_exporters=metrics_exporters,
@@ -100,10 +100,10 @@ def _model_base_test( # pylint: disable=too-many-arguments, too-many-locals
     nn.save_model("test.pth.tar")
 
     Trainer(
-        model_class,
         dataset_train,
         dataset_val,
         dataset_test,
+        model_class,
         pretrained_model="test.pth.tar")
 
 class TestTrainer(unittest.TestCase):
@@ -117,10 +117,10 @@ class TestTrainer(unittest.TestCase):
 
     def test_ginet_sigmoid(self):
         _model_base_test(
+            "tests/hdf5/1ATN_ppi.hdf5",
+            "tests/hdf5/1ATN_ppi.hdf5",
+            "tests/hdf5/1ATN_ppi.hdf5",
             GINet,
-            "tests/hdf5/1ATN_ppi.hdf5",
-            "tests/hdf5/1ATN_ppi.hdf5",
-            "tests/hdf5/1ATN_ppi.hdf5",
             ["type", "polarity", "bsa", "depth", "hse", "ic", "pssm"],
             ["dist"],
             "reg",
@@ -131,11 +131,11 @@ class TestTrainer(unittest.TestCase):
         )
 
     def test_ginet(self):
-        _model_base_test(
-            GINet,            
+        _model_base_test(           
             "tests/hdf5/1ATN_ppi.hdf5",
             "tests/hdf5/1ATN_ppi.hdf5",
             "tests/hdf5/1ATN_ppi.hdf5",
+            GINet,
             ["type", "polarity", "bsa", "depth", "hse", "ic", "pssm"],
             ["dist"],
             "reg",
@@ -149,10 +149,10 @@ class TestTrainer(unittest.TestCase):
 
     def test_ginet_class(self):
         _model_base_test(
+            "tests/hdf5/variants.hdf5",
+            "tests/hdf5/variants.hdf5",
+            "tests/hdf5/variants.hdf5",
             GINet,
-            "tests/hdf5/variants.hdf5",
-            "tests/hdf5/variants.hdf5",
-            "tests/hdf5/variants.hdf5",
             ["polarity", "ic", "pssm"],
             ["dist"],
             "class",
@@ -166,10 +166,10 @@ class TestTrainer(unittest.TestCase):
 
     def test_fout(self):
         _model_base_test(
+            "tests/hdf5/test.hdf5",
+            "tests/hdf5/test.hdf5",
+            "tests/hdf5/test.hdf5",
             FoutNet,
-            "tests/hdf5/test.hdf5",
-            "tests/hdf5/test.hdf5",
-            "tests/hdf5/test.hdf5",
             ["type", "polarity", "bsa", "depth", "hse", "ic", "pssm"],
             ["dist"],
             "class",
@@ -181,10 +181,10 @@ class TestTrainer(unittest.TestCase):
 
     def test_sgat(self):
         _model_base_test(
+            "tests/hdf5/1ATN_ppi.hdf5",
+            "tests/hdf5/1ATN_ppi.hdf5",
+            "tests/hdf5/1ATN_ppi.hdf5",
             sGAT,
-            "tests/hdf5/1ATN_ppi.hdf5",
-            "tests/hdf5/1ATN_ppi.hdf5",
-            "tests/hdf5/1ATN_ppi.hdf5",
             ["type", "polarity", "bsa", "depth", "hse", "ic", "pssm"],
             ["dist"],
             "reg",
@@ -196,10 +196,10 @@ class TestTrainer(unittest.TestCase):
 
     def test_naive(self):
         _model_base_test(
+            "tests/hdf5/test.hdf5",
+            "tests/hdf5/test.hdf5",
+            "tests/hdf5/test.hdf5",
             NaiveNetwork,
-            "tests/hdf5/test.hdf5",
-            "tests/hdf5/test.hdf5",
-            "tests/hdf5/test.hdf5",
             ["type", "polarity", "bsa", "depth", "hse", "ic", "pssm"],
             ["dist"],
             "reg",
@@ -212,10 +212,10 @@ class TestTrainer(unittest.TestCase):
     def test_incompatible_regression(self):
         with pytest.raises(ValueError):
             _model_base_test(
+                "tests/hdf5/1ATN_ppi.hdf5",
+                "tests/hdf5/1ATN_ppi.hdf5",
+                "tests/hdf5/1ATN_ppi.hdf5",
                 sGAT,
-                "tests/hdf5/1ATN_ppi.hdf5",
-                "tests/hdf5/1ATN_ppi.hdf5",
-                "tests/hdf5/1ATN_ppi.hdf5",
                 ["type", "polarity", "bsa", "depth", "hse", "ic", "pssm"],
                 ["dist"],
                 "reg",
@@ -228,10 +228,10 @@ class TestTrainer(unittest.TestCase):
     def test_incompatible_classification(self):
         with pytest.raises(ValueError):
             _model_base_test(
+                "tests/hdf5/variants.hdf5",
+                "tests/hdf5/variants.hdf5",
+                "tests/hdf5/variants.hdf5",
                 GINet,
-                "tests/hdf5/variants.hdf5",
-                "tests/hdf5/variants.hdf5",
-                "tests/hdf5/variants.hdf5",
                 ["size", "polarity", "sasa", "ic", "pssm"],
                 ["dist"],
                 "class",
@@ -243,10 +243,10 @@ class TestTrainer(unittest.TestCase):
 
     def test_no_val(self):
         _model_base_test(
-            GINet,
             "tests/hdf5/test.hdf5",
             None,
             "tests/hdf5/test.hdf5",
+            GINet,
             ["polarity", "ic", "pssm"],
             ["dist"],
             "class",
@@ -259,10 +259,10 @@ class TestTrainer(unittest.TestCase):
     def test_incompatible_pretrained_no_test(self):
         with pytest.raises(ValueError):
             _model_base_test(
-                GINet,
                 "tests/hdf5/test.hdf5",
                 None,
                 None,
+                GINet,
                 ["polarity", "ic", "pssm"],
                 ["dist"],
                 "class",
@@ -282,8 +282,8 @@ class TestTrainer(unittest.TestCase):
             root="./")
 
         nn = Trainer(
-            NaiveNetwork,
-            dataset,
+            dataset_train = dataset,
+            Net = NaiveNetwork,
             task = "class"
         )
 
@@ -302,9 +302,8 @@ class TestTrainer(unittest.TestCase):
         nn.save_model("test.pth.tar")
 
         nn_pretrained = Trainer(
-            NaiveNetwork,
-            dataset_train=dataset,
             dataset_test=dataset,
+            Net = NaiveNetwork,
             pretrained_model="test.pth.tar")
 
         assert isinstance(nn_pretrained.optimizer, optimizer)
@@ -319,8 +318,8 @@ class TestTrainer(unittest.TestCase):
             root="./")
 
         nn = Trainer(
-            NaiveNetwork,
-            dataset,
+            dataset_train = dataset,
+            Net = NaiveNetwork,
             task = "class"
         )
 

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -310,6 +310,41 @@ class TestTrainer(unittest.TestCase):
                 dataset_test = dataset,
                 pretrained_model="test.pth.tar")
 
+    def test_no_valid_provided(self):
+
+        dataset = HDF5DataSet(
+            hdf5_path="tests/hdf5/test.hdf5",
+            target="binary",
+            root="./")
+
+        trainer = Trainer(
+            dataset_train = dataset,
+            Net = GINet,
+            task = "class",
+            batch_size = 1
+        )
+
+        assert len(trainer.train_loader) == int(0.75 * len(dataset))
+        assert len(trainer.valid_loader) == int(0.25 * len(dataset))
+
+    def test_no_valid_full_train(self):
+
+        dataset = HDF5DataSet(
+            hdf5_path="tests/hdf5/test.hdf5",
+            target="binary",
+            root="./")
+
+        trainer = Trainer(
+            dataset_train = dataset,
+            Net = GINet,
+            val_size = 0,
+            task = "class",
+            batch_size = 1
+        )
+
+        assert len(trainer.train_loader) == len(dataset)
+        assert trainer.valid_loader == None
+
     def test_optim(self):
 
         dataset = HDF5DataSet(

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -241,7 +241,7 @@ class TestTrainer(unittest.TestCase):
                 "mcl",
             )
 
-    def test_no_val(self):
+    def test_no_val(self): # check shapes of train and valid
         _model_base_test(
             "tests/hdf5/test.hdf5",
             None,
@@ -256,23 +256,77 @@ class TestTrainer(unittest.TestCase):
             "mcl",
         )
 
-    def test_incompatible_pretrained_no_test(self):
+# add one with val_size = 0
+# change nn to trainer everywhere
+
+    def test_incompatible_no_pretrained_no_train(self):
         with pytest.raises(ValueError):
-            _model_base_test(
-                "tests/hdf5/test.hdf5",
-                None,
-                None,
-                GINet,
-                ["polarity", "ic", "pssm"],
-                ["dist"],
-                "class",
-                "binary",
-                [TensorboardBinaryClassificationExporter(self.work_directory)],
-                False,
-                "mcl",
+
+            dataset = HDF5DataSet(
+                hdf5_path="tests/hdf5/test.hdf5",
+                target="binary",
+                root="./")
+
+            Trainer(
+                dataset_test = dataset,
+                Net = NaiveNetwork,
+                task = "class"
             )
 
-        assert len(os.listdir(self.work_directory)) > 0
+    def test_incompatible_no_pretrained_no_Net(self):
+        with pytest.raises(ValueError):
+            dataset = HDF5DataSet(
+                hdf5_path="tests/hdf5/test.hdf5",
+                target="binary",
+                root="./")
+
+            Trainer(
+                dataset_train = dataset,
+                task = "class"
+            )
+
+    def test_incompatible_pretrained_no_test(self):
+        with pytest.raises(ValueError):
+            dataset = HDF5DataSet(
+                hdf5_path="tests/hdf5/test.hdf5",
+                target="binary",
+                root="./")
+
+            trainer = Trainer(
+                dataset_train = dataset,
+                Net = GINet,
+                task = "class"
+            )
+
+            trainer.train(nepoch=10, validate=True)
+
+            trainer.save_model("test.pth.tar")
+
+            Trainer(
+                dataset_train = dataset,
+                Net = GINet,
+                pretrained_model="test.pth.tar")
+
+    def test_incompatible_pretrained_no_Net(self):
+        with pytest.raises(ValueError):
+            dataset = HDF5DataSet(
+                hdf5_path="tests/hdf5/test.hdf5",
+                target="binary",
+                root="./")
+
+            trainer = Trainer(
+                dataset_train = dataset,
+                Net = GINet,
+                task = "class"
+            )
+
+            trainer.train(nepoch=10, validate=True)
+
+            trainer.save_model("test.pth.tar")
+
+            Trainer(
+                dataset_test = dataset,
+                pretrained_model="test.pth.tar")
 
     def test_optim(self):
 

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -241,24 +241,6 @@ class TestTrainer(unittest.TestCase):
                 "mcl",
             )
 
-    def test_no_val(self): # check shapes of train and valid
-        _model_base_test(
-            "tests/hdf5/test.hdf5",
-            None,
-            "tests/hdf5/test.hdf5",
-            GINet,
-            ["polarity", "ic", "pssm"],
-            ["dist"],
-            "class",
-            "binary",
-            [TensorboardBinaryClassificationExporter(self.work_directory)],
-            False,
-            "mcl",
-        )
-
-# add one with val_size = 0
-# change nn to trainer everywhere
-
     def test_incompatible_no_pretrained_no_train(self):
         with pytest.raises(ValueError):
 

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -65,7 +65,7 @@ def _model_base_test( # pylint: disable=too-many-arguments, too-many-locals
     else:
         dataset_test = None
 
-    nn = Trainer(
+    trainer = Trainer(
         dataset_train,
         dataset_val,
         dataset_test,
@@ -78,7 +78,7 @@ def _model_base_test( # pylint: disable=too-many-arguments, too-many-locals
 
     if torch.cuda.is_available():
         _log.debug("cuda is available, testing that the model is cuda")
-        for parameter in nn.model.parameters():
+        for parameter in trainer.model.parameters():
             assert parameter.is_cuda, f"{parameter} is not cuda"
 
         data = dataset_train.get(0)
@@ -95,9 +95,9 @@ def _model_base_test( # pylint: disable=too-many-arguments, too-many-locals
     else:
         _log.debug("cuda is not available")
 
-    nn.train(nepoch=10, validate=True)
+    trainer.train(nepoch=10, validate=True)
 
-    nn.save_model("test.pth.tar")
+    trainer.save_model("test.pth.tar")
 
     Trainer(
         dataset_train,
@@ -352,7 +352,7 @@ class TestTrainer(unittest.TestCase):
             target="binary",
             root="./")
 
-        nn = Trainer(
+        trainer = Trainer(
             dataset_train = dataset,
             Net = NaiveNetwork,
             task = "class"
@@ -362,24 +362,24 @@ class TestTrainer(unittest.TestCase):
         lr = 0.1
         weight_decay = 1e-04
 
-        nn.configure_optimizers(optimizer, lr, weight_decay)
+        trainer.configure_optimizers(optimizer, lr, weight_decay)
 
-        assert isinstance(nn.optimizer, optimizer)
-        assert nn.lr == lr
-        assert nn.weight_decay == weight_decay
+        assert isinstance(trainer.optimizer, optimizer)
+        assert trainer.lr == lr
+        assert trainer.weight_decay == weight_decay
 
-        nn.train(nepoch=10, validate=True)
+        trainer.train(nepoch=10, validate=True)
 
-        nn.save_model("test.pth.tar")
+        trainer.save_model("test.pth.tar")
 
-        nn_pretrained = Trainer(
+        trainer_pretrained = Trainer(
             dataset_test=dataset,
             Net = NaiveNetwork,
             pretrained_model="test.pth.tar")
 
-        assert isinstance(nn_pretrained.optimizer, optimizer)
-        assert nn_pretrained.lr == lr
-        assert nn_pretrained.weight_decay == weight_decay
+        assert isinstance(trainer_pretrained.optimizer, optimizer)
+        assert trainer_pretrained.lr == lr
+        assert trainer_pretrained.weight_decay == weight_decay
 
     def test_default_optim(self):
 
@@ -388,15 +388,15 @@ class TestTrainer(unittest.TestCase):
             target="binary",
             root="./")
 
-        nn = Trainer(
+        trainer = Trainer(
             dataset_train = dataset,
             Net = NaiveNetwork,
             task = "class"
         )
 
-        assert isinstance(nn.optimizer, torch.optim.Adam)
-        assert nn.lr == 0.001
-        assert nn.weight_decay == 1e-05
+        assert isinstance(trainer.optimizer, torch.optim.Adam)
+        assert trainer.lr == 0.001
+        assert trainer.weight_decay == 1e-05
 
 
 if __name__ == "__main__":

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -5,7 +5,7 @@ import unittest
 import pytest
 import logging
 import torch
-from deeprankcore.NeuralNet import NeuralNet
+from deeprankcore.Trainer import Trainer
 from deeprankcore.DataSet import HDF5DataSet
 from deeprankcore.ginet import GINet
 from deeprankcore.foutnet import FoutNet
@@ -65,7 +65,7 @@ def _model_base_test( # pylint: disable=too-many-arguments, too-many-locals
     else:
         dataset_test = None
 
-    nn = NeuralNet(
+    nn = Trainer(
         model_class,
         dataset_train,
         dataset_val,
@@ -99,14 +99,14 @@ def _model_base_test( # pylint: disable=too-many-arguments, too-many-locals
 
     nn.save_model("test.pth.tar")
 
-    NeuralNet(
+    Trainer(
         model_class,
         dataset_train,
         dataset_val,
         dataset_test,
         pretrained_model="test.pth.tar")
 
-class TestNeuralNet(unittest.TestCase):
+class TestTrainer(unittest.TestCase):
     @classmethod
     def setUpClass(class_):
         class_.work_directory = tempfile.mkdtemp()
@@ -281,7 +281,7 @@ class TestNeuralNet(unittest.TestCase):
             target="binary",
             root="./")
 
-        nn = NeuralNet(
+        nn = Trainer(
             NaiveNetwork,
             dataset,
             task = "class"
@@ -301,7 +301,7 @@ class TestNeuralNet(unittest.TestCase):
 
         nn.save_model("test.pth.tar")
 
-        nn_pretrained = NeuralNet(
+        nn_pretrained = Trainer(
             NaiveNetwork,
             dataset_train=dataset,
             dataset_test=dataset,
@@ -318,7 +318,7 @@ class TestNeuralNet(unittest.TestCase):
             target="binary",
             root="./")
 
-        nn = NeuralNet(
+        nn = Trainer(
             NaiveNetwork,
             dataset,
             task = "class"


### PR DESCRIPTION
Main edits

**General**
- Improved documentation in Trainer.py and DataSet.py
- Added `_` in front of methods meant to be only internal to the classes, so not supposed to be called by the user or somewhere outside the classes, in Trainer.py _and_ DataSet.py. 

**DataSet.py**
- Inserted a check for the target Dataset to be numerical since we do not support the categorical targets (for our experiments we have numerical target values so we don't care for now, but it's a nice addition for the future - see issue #197).

**NeuralNet.py (Trainer.py)**
- Modified NeuralNet class and module to Trainer
- Moved `_PreCluster` and `_DivideDataSet` functions to Trainer.py module since they are used only in there. I put `_PreCluster` as `Trainer` method and I left `_DivideDataSet` as a function for now. In the future, we may want to move `_PreCluster` and its calls to HDF5DataSet class (I think it makes more sense to have it there), and `_DivideDataSet` could be made a Trainer method.
- Moved `classes_to_idx` to `Trainer.format_output` and changed it from attribute to local method variable since it's used only there.
- Removed `Trainer.compute_class_weights` method because it was never used. 
- Removed `Trainer.update_name` method because it was never used. 
- Raise an error if both `dataset_val` and `val_size` are set. Only one between them should be set. 
- If there is no `pretrained_model`, raise an error if either:
  - there is no `dataset_train`
  - there is no `Net`
- in `Trainer._load_pretrained_model` method, create self.test_loader _after_ having called `_PreCluster`.
- in `Trainer.train` method, raise an error if `validate` is True and there is no validation loader. 
- in `Trainer.test` method:
  - call `_PreCluster` only if self.cluster_nodes is in ('mcl', 'louvain')
  - raise an error if `dataset_test` provided to `test()` is None **and** `test_loader` attribute is None (meaning no dataset test was provided neither when Trainer was initialized). 