### PR TITLE
build with pytorch 1.12.1

### DIFF
--- a/.github/actions/install-python-and-package/action.yml
+++ b/.github/actions/install-python-and-package/action.yml
@@ -58,7 +58,8 @@ runs:
         # Only way to install msms is through conda
         conda install -c bioconda msms
         # We install pytorch with conda because otherwise it breaks
-        conda install pytorch -c pytorch
+        # Build is failing on pytorch 1.13 (as of 3 Nov 2022), hardcode pytorch 1.12.1 for now
+        conda install pytorch=1.12.1 -c pytorch
         # In the future, release h5xplorer on PyPI
         pip install git+https://github.com/DeepRank/h5xplorer.git@master
 


### PR DESCRIPTION
build is failing with newest pytorch (1.13), but should work with this pytorch version (1.12.1).
let's check again in some time if pytorch 1.13 also works