### PR TITLE
fix: list all submodules imported from deeprankcore.features using pkgutil

### DIFF
--- a/.github/actions/install-python-and-package/action.yml
+++ b/.github/actions/install-python-and-package/action.yml
@@ -57,9 +57,9 @@ runs:
         cd ../..
         # Only way to install msms is through conda
         conda install -c bioconda msms
-        # We install pytorch with conda because otherwise it breaks
-        # Build is failing on pytorch 1.13 (as of 3 Nov 2022), hardcode pytorch 1.12.1 for now
-        conda install pytorch=1.12.1 -c pytorch
+        # Safest way to install PyTorch and PyTorch Geometric is through conda
+        conda install pytorch torchvision torchaudio pytorch-cuda=11.7 -c pytorch -c nvidia
+        conda install pyg -c pyg
         # In the future, release h5xplorer on PyPI
         pip install git+https://github.com/DeepRank/h5xplorer.git@master
 
@@ -68,3 +68,4 @@ runs:
       run: python3 -m pip install .[${{ inputs.extras-require }}]
       env:
         CONDA_PREFIX: /usr/share/miniconda
+        

--- a/deeprankcore/query.py
+++ b/deeprankcore/query.py
@@ -9,8 +9,9 @@ from types import ModuleType
 from functools import partial
 from multiprocessing import Pool
 import importlib
-from os.path import basename, isfile, join
+from os.path import basename
 import h5py
+import pkgutil
 from deeprankcore.utils.graph import Graph
 from deeprankcore.molstruct.aminoacid import AminoAcid
 from deeprankcore.utils.buildgraph import (
@@ -22,6 +23,7 @@ from deeprankcore.utils.buildgraph import (
 from deeprankcore.utils.parsing.pssm import parse_pssm
 from deeprankcore.utils.graph import build_residue_graph, build_atomic_graph
 from deeprankcore.molstruct.variant import SingleResidueVariant
+import deeprankcore.features
 
 
 _log = logging.getLogger(__name__)
@@ -236,8 +238,7 @@ class QueryCollection:
             prefix = "processed-queries"
         
         if feature_modules is None:
-            feature_modules = glob(join('./deeprankcore/features/', "*.py"))
-            feature_names = [basename(f)[:-3] for f in feature_modules if isfile(f) and not f.endswith('__init__.py')]
+            feature_names = [modname for _, modname, _ in pkgutil.iter_modules(deeprankcore.features.__path__)]
         else:
             feature_names = [basename(m.__file__)[:-3] for m in feature_modules]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,11 +52,6 @@ install_requires =
     freesasa >= 2.1.0
     tensorboard >= 2.9.0
     protobuf <= 3.20.1
-    torch-scatter >= 2.0.6
-    torch-sparse >= 0.6.13
-    torch-cluster >= 1.6.0
-    torch-spline-conv >= 1.2.1
-    torch-geometric >= 2.0.4
 
 [options.extras_require]
 dev =
@@ -67,7 +62,8 @@ doc =
     sphinx
     sphinx_rtd_theme
 test =
-    prospector[with_pyroma]
+    pylint <= 2.15.3  
+    prospector[with_pyroma] <= 1.7.7
     bump2version
     coverage
     pycodestyle


### PR DESCRIPTION
The process method of Query was failing if the script was run outside the package, due to the way in which we listed features modules' names. Using `pkgutil` solves the issue. 