### PR TITLE
perf: add try except clause to `_preprocess_one_query` method of `QueryCollection` class

### DIFF
--- a/deeprankcore/query.py
+++ b/deeprankcore/query.py
@@ -191,9 +191,12 @@ class QueryCollection:
         feature_modules = [
             importlib.import_module('deeprankcore.features.' + name) for name in feature_names]
 
-        graph = query.build(feature_modules)
-
-        graph.write_to_hdf5(output_path)
+        try:
+            graph = query.build(feature_modules)
+            graph.write_to_hdf5(output_path)
+        except ValueError as e:
+            _log.error(e)
+            _log.warning(f'Query {query.get_query_id()}\'s graph was not saved in the hdf5 file; check the query\'s files')
 
     def process(
         self, 


### PR DESCRIPTION
If a graph build fails, now the error is caught and printed in the log, together with the id of the query failed. 