### PR TITLE
fix: let `classes` argument be also categorical

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ DeeprankCore documentation can be found here : https://deeprankcore.rtfd.io/.
       - [Custom GNN](#custom-gnn)
   - [h5x support](#h5x-support)
   - [For the developers](#for-the-developers)
+    - [Branching](#branching)
+    - [Pull Requests](#pull-requests)
     - [Software release](#software-release)
 
 ## Installation
@@ -334,6 +336,15 @@ After installing  `h5xplorer`  (https://github.com/DeepRank/h5xplorer), you can 
 
 ## For the developers
 
+### Branching
+
+When creating a new branch, please follow the following convention: `<issue_number>_<description>_<author_name>`.
+
+### Pull Requests
+
+When creating a Pull Request, please follow the following convention: `<type>: <description>`. Example _types_ are `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and other based on the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines).
+
 ### Software release
 
 Before creating a new package release, make sure to have updated all version strings in the source code. An easy way to do it is to run `bump2version [part]` from command line after having installed [bump2version](https://pypi.org/project/bump2version/) on your local environment. Instead of `[part]`, type the part of the version to increase, e.g. minor. The settings in `.bumpversion.cfg` will take care of updating all the files containing version strings. 
+

--- a/README.md
+++ b/README.md
@@ -338,11 +338,11 @@ After installing  `h5xplorer`  (https://github.com/DeepRank/h5xplorer), you can 
 
 ### Branching
 
-When creating a new branch, please follow the following convention: `<issue_number>_<description>_<author_name>`.
+When creating a new branch, please use the following convention: `<issue_number>_<description>_<author_name>`.
 
 ### Pull Requests
 
-When creating a Pull Request, please follow the following convention: `<type>: <description>`. Example _types_ are `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and other based on the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines).
+When creating a pull request, please use the following convention: `<type>: <description>`. Example _types_ are `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, and others based on the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines).
 
 ### Software release
 

--- a/deeprankcore/dataset.py
+++ b/deeprankcore/dataset.py
@@ -325,6 +325,7 @@ class GraphDataset(Dataset):
         if self.task == targets.CLASSIF:
             if classes is None:
                 self.classes = [0, 1]
+                _log.info(f'Target classes set up to: {self.classes}')
             else:
                 self.classes = classes
 

--- a/deeprankcore/dataset.py
+++ b/deeprankcore/dataset.py
@@ -60,7 +60,7 @@ class GraphDataset(Dataset):
         node_features: Union[List[str], str] = "all",
         edge_features: Union[List[str], str] = "all",
         clustering_method: str = "mcl",
-        classes: List = None,
+        classes: Union[List[str], List[int], List[float]] = None,
         tqdm: bool = True,
         root: str = "./",
         transform: Callable = None,

--- a/deeprankcore/trainer.py
+++ b/deeprankcore/trainer.py
@@ -592,7 +592,7 @@ class Trainer():
             # For categorical cross entropy, the target must be a one-dimensional tensor
             # of class indices with type long and the output should have raw, unnormalized values
             target = torch.tensor(
-                [self.classes_to_idx[int(x)] if ~isinstance(x, str) else self.classes_to_idx[x] for x in target]
+                [self.classes_to_idx[x] if isinstance(x, str) else self.classes_to_idx[int(x)] for x in target]
             ).to(self.device)
 
         elif self.task == targets.REGRESS:

--- a/deeprankcore/trainer.py
+++ b/deeprankcore/trainer.py
@@ -592,7 +592,7 @@ class Trainer():
             # For categorical cross entropy, the target must be a one-dimensional tensor
             # of class indices with type long and the output should have raw, unnormalized values
             target = torch.tensor(
-                [self.classes_to_idx[int(x)] for x in target]
+                [self.classes_to_idx[int(x)] if type(x) != str else self.classes_to_idx[x] for x in target]
             ).to(self.device)
 
         elif self.task == targets.REGRESS:

--- a/deeprankcore/trainer.py
+++ b/deeprankcore/trainer.py
@@ -592,7 +592,7 @@ class Trainer():
             # For categorical cross entropy, the target must be a one-dimensional tensor
             # of class indices with type long and the output should have raw, unnormalized values
             target = torch.tensor(
-                [self.classes_to_idx[int(x)] if isinstance(x, str) else self.classes_to_idx[x] for x in target]
+                [self.classes_to_idx[int(x)] if ~isinstance(x, str) else self.classes_to_idx[x] for x in target]
             ).to(self.device)
 
         elif self.task == targets.REGRESS:

--- a/deeprankcore/trainer.py
+++ b/deeprankcore/trainer.py
@@ -592,7 +592,7 @@ class Trainer():
             # For categorical cross entropy, the target must be a one-dimensional tensor
             # of class indices with type long and the output should have raw, unnormalized values
             target = torch.tensor(
-                [self.classes_to_idx[int(x)] if type(x) != str else self.classes_to_idx[x] for x in target]
+                [self.classes_to_idx[int(x)] if isinstance(x, str) else self.classes_to_idx[x] for x in target]
             ).to(self.device)
 
         elif self.task == targets.REGRESS:


### PR DESCRIPTION
- `classes` argument of GraphDataset now can be also made of strings
- If it's None, it's defaulted to [0, 1] and this is printed in the logging file
- Add in the readme useful info for developers