### PR TITLE
refactor: fix `transform_sigmoid` logic and move it to `GraphDataset` class

### DIFF
--- a/deeprankcore/dataset.py
+++ b/deeprankcore/dataset.py
@@ -120,10 +120,9 @@ class GraphDataset(Dataset):
             edge_features_transform (function, optional): transformation applied to the edge features.
                 Defaults to lambdax:np.tanh(-x/2+2)+1.
 
-            target_transform (bool, optional): Bool to decide whether or not to apply a sigmoid transformation to the
-                target (for regression only). If True, first a log and then a sigmoid transformations
-                are applied to the target. This can result in a more uniform target distribution,
-                can speed up the optimization and puts target value between 0 and 1.
+            target_transform (bool, optional): Apply a log and then a sigmoid transformation to the target (for regression only).
+                This puts the target value between 0 and 1, and can result in 
+                a more uniform target distribution and speed up the optimization.
                 Defaults to False.
 
             target_filter (dictionary, optional): Dictionary of type [target: cond] to filter the molecules.

--- a/deeprankcore/trainer.py
+++ b/deeprankcore/trainer.py
@@ -31,7 +31,6 @@ class Trainer():
                 pretrained_model: str = None,
                 batch_size: int = 32,
                 shuffle: bool = True,
-                transform_sigmoid: Optional[bool] = False,
                 output_exporters: Optional[List[OutputExporter]] = None,
             ):
         """Class from which the network is trained, evaluated and tested
@@ -65,9 +64,6 @@ class Trainer():
             batch_size (int, optional): defaults to 32.
 
             shuffle (bool, optional): shuffle the dataloaders data. Defaults to True.
-
-            transform_sigmoid: whether or not to apply a sigmoid transformation to the output (for regression only). 
-                This can speed up the optimization and puts the value between 0 and 1.
 
             output_exporters: the output exporters to use for saving/exploring/plotting predictions/targets/losses
                 over the epochs. Defaults to HDF5OutputExporter, which saves all the results in an hdf5 file stored
@@ -104,7 +100,6 @@ class Trainer():
             self.class_weights = class_weights
 
             self.shuffle = shuffle
-            self.transform_sigmoid = transform_sigmoid
 
             self.subset = self.dataset_train.subset
             self.node_features = self.dataset_train.node_features
@@ -596,13 +591,7 @@ class Trainer():
             ).to(self.device)
 
         elif self.task == targets.REGRESS:
-            if self.transform_sigmoid is True:
-
-                # Sigmoid(x) = 1 / (1 + exp(-x))
-                pred = torch.sigmoid(pred.reshape(-1))
-
-            else:
-                pred = pred.reshape(-1)
+            pred = pred.reshape(-1)
 
         if target is not None:
             target = target.to(self.device)
@@ -654,7 +643,6 @@ class Trainer():
         self.classes = state["classes"]
         self.shuffle = state["shuffle"]
         self.clustering_method = state["clustering_method"]
-        self.transform_sigmoid = state["transform_sigmoid"]
         self.optimizer = state["optimizer"]
         self.opt_loaded_state_dict = state["optimizer_state"]
         self.model_load_state_dict = state["model_state"]
@@ -683,8 +671,7 @@ class Trainer():
             "weight_decay": self.weight_decay,
             "subset": self.subset,
             "shuffle": self.shuffle,
-            "clustering_method": self.clustering_method,
-            "transform_sigmoid": self.transform_sigmoid,
+            "clustering_method": self.clustering_method
         }
 
         torch.save(state, filename)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -145,6 +145,31 @@ class TestDataSet(unittest.TestCase):
         assert n == len(dataset)
 
         hdf5.close()
+
+    def test_target_transform(self):
+
+        dataset = GraphDataset(
+            hdf5_path = "tests/data/hdf5/train.hdf5",
+            target = "BA", # continuous values
+            task = 'regress',
+            target_transform = True
+        )
+
+        for i in range(len(dataset)):
+            assert(0 <= dataset.get(i).y <= 1)
+
+    def test_invalid_target_transform(self):
+
+        dataset = GraphDataset(
+            hdf5_path = "tests/data/hdf5/train.hdf5",
+            target = "BA", # continuous values
+            task = 'classif',
+            target_transform = True # only for regression
+        )
+
+        with self.assertRaises(ValueError):
+            dataset.get(0)
+
         
 
 if __name__ == "__main__":

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -34,7 +34,7 @@ def _model_base_test( # pylint: disable=too-many-arguments, too-many-locals
     edge_features,
     task,
     target,
-    transform_sigmoid,
+    target_transform,
     output_exporters,
     clustering_method,
     use_cuda = False
@@ -44,18 +44,20 @@ def _model_base_test( # pylint: disable=too-many-arguments, too-many-locals
         hdf5_path=train_hdf5_path,
         node_features=node_features,
         edge_features=edge_features,
-        task = task,
         target=target,
-        clustering_method=clustering_method)
+        task = task,
+        clustering_method=clustering_method,
+        target_transform = target_transform)
 
     if val_hdf5_path is not None:
         dataset_val = GraphDataset(
             hdf5_path=val_hdf5_path,
             node_features=node_features,
             edge_features=edge_features,
-            task = task,
             target=target,
-            clustering_method=clustering_method)
+            task = task,
+            clustering_method=clustering_method,
+            target_transform = target_transform)
     else:
         dataset_val = None
 
@@ -66,7 +68,8 @@ def _model_base_test( # pylint: disable=too-many-arguments, too-many-locals
             edge_features=edge_features,
             target=target,
             task=task,
-            clustering_method=clustering_method)
+            clustering_method=clustering_method,
+            target_transform = target_transform)
     else:
         dataset_test = None
 
@@ -76,7 +79,6 @@ def _model_base_test( # pylint: disable=too-many-arguments, too-many-locals
         dataset_val,
         dataset_test,
         batch_size=64,
-        transform_sigmoid=transform_sigmoid,
         output_exporters=output_exporters,
     )
 


### PR DESCRIPTION
- Move `transform_sigmoid` parameter, now called `target_transform`, to GraphDataset class
- Only the target (ground truth) is now transformed with a log and a sigmoid function. The prediction will be done according to such a transformed target. 
- An error is raised if the user tries to set`target_transform` as True but the task is not regression
- Tests and docs have been added accordingly