### PR TITLE
docs: improve `clustering_method` description and default value

### DIFF
--- a/deeprankcore/dataset.py
+++ b/deeprankcore/dataset.py
@@ -59,7 +59,7 @@ class GraphDataset(Dataset):
         task: str = None,
         node_features: Union[List[str], str] = "all",
         edge_features: Union[List[str], str] = "all",
-        clustering_method: str = "mcl",
+        clustering_method: str = None,
         classes: Union[List[str], List[int], List[float]] = None,
         tqdm: bool = True,
         root: str = "./",
@@ -107,7 +107,7 @@ class GraphDataset(Dataset):
                 The latter tensor is saved into the hdf5 file as a Dataset called "depth_1". Both "depth_0" and "depth_1"
                 Datasets belong to the "cluster" Group. They are saved in the hdf5 file to make them available to networks
                 that make use of clustering methods.
-                Defaults to "mcl".
+                Defaults to None.
 
             classes (list, optional): define the dataset target classes in classification mode. Defaults to [0, 1].
 

--- a/deeprankcore/dataset.py
+++ b/deeprankcore/dataset.py
@@ -98,9 +98,16 @@ class GraphDataset(Dataset):
                 or some defined edge features (provide a list, example: ["dist", "coulomb"]).
                 The complete list can be found in deeprankcore/domain/features.py
 
-            clustering_method (str, optional): perform node clustering ('mcl', Markov Clustering,
-                or 'louvain' algorithm). Note that this parameter can be None only if the neural
-                network doesn't expects clusters (e.g. naive_gnn). Defaults to "mcl".
+            clustering_method (str, optional): "mcl" for Markov cluster algorithm (see https://micans.org/mcl/),
+                or "louvain" for Louvain method (see https://en.wikipedia.org/wiki/Louvain_method).
+                In both options, for each graph, the chosen method first finds communities (clusters) of nodes and generates
+                a torch tensor whose elements represent the cluster to which the node belongs to. Each tensor is then saved
+                in the hdf5 file as a Dataset called "depth_0". Then, all cluster members beloging to the same community are
+                pooled into a single node, and the resulting tensor is used to find communities among the pooled clusters.
+                The latter tensor is saved into the hdf5 file as a Dataset called "depth_1". Both "depth_0" and "depth_1"
+                Datasets belong to the "cluster" Group. They are saved in the hdf5 file to make them available to networks
+                that make use of clustering methods.
+                Defaults to "mcl".
 
             classes (list, optional): define the dataset target classes in classification mode. Defaults to [0, 1].
 

--- a/deeprankcore/trainer.py
+++ b/deeprankcore/trainer.py
@@ -260,7 +260,6 @@ class Trainer():
             clust_grp = grp.require_group("clustering")
 
             if self.clustering_method.lower() in clust_grp:
-                #_log.info(f"Deleting previous data for mol {mol} method {method}")
                 del clust_grp[self.clustering_method.lower()]
 
             method_grp = clust_grp.create_group(self.clustering_method.lower())

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -286,6 +286,7 @@ class TestTrainer(unittest.TestCase):
             dataset = GraphDataset(
                 hdf5_path="tests/data/hdf5/test.hdf5",
                 target=targets.BINARY,
+                clustering_method="mcl"
             )
 
             trainer = Trainer(
@@ -307,6 +308,7 @@ class TestTrainer(unittest.TestCase):
             dataset = GraphDataset(
                 hdf5_path="tests/data/hdf5/test.hdf5",
                 target=targets.BINARY,
+                clustering_method="mcl"
             )
 
             trainer = Trainer(
@@ -327,6 +329,7 @@ class TestTrainer(unittest.TestCase):
         dataset = GraphDataset(
             hdf5_path="tests/data/hdf5/test.hdf5",
             target=targets.BINARY,
+            clustering_method="mcl"
         )
 
         trainer = Trainer(
@@ -378,7 +381,7 @@ class TestTrainer(unittest.TestCase):
         assert trainer.weight_decay == weight_decay
 
         with warnings.catch_warnings(record=UserWarning):
-            trainer.train(nepoch=3, validate=True)
+            trainer.train(nepoch=3)
             trainer.save_model("test.pth.tar")
 
             trainer_pretrained = Trainer(
@@ -455,13 +458,15 @@ class TestTrainer(unittest.TestCase):
             dataset_train = GraphDataset(
                 hdf5_path="tests/data/hdf5/test.hdf5",
                 target=targets.BINARY,
-                edge_features=[Efeat.DISTANCE, Efeat.COVALENT]
+                edge_features=[Efeat.DISTANCE, Efeat.COVALENT],
+                clustering_method="mcl"
             )
             
             dataset_test = GraphDataset(
                 hdf5_path="tests/data/hdf5/test.hdf5",
                 target=targets.BINARY,
-                edge_features=[Efeat.DISTANCE]
+                edge_features=[Efeat.DISTANCE],
+                clustering_method="mcl"
             )
 
             trainer = Trainer(


### PR DESCRIPTION
- Improve docs about the clustering operations and their usage
- Default `clustering_method ` of `GraphDataset` to None, since clustering is specific for only some networks and shouldn't be done by default