### PR TITLE
fix: `num_workers` parameter of Dataloader object

### DIFF
--- a/deeprankcore/dataset.py
+++ b/deeprankcore/dataset.py
@@ -31,7 +31,8 @@ class DeeprankDataset(Dataset):
                  root_directory_path: str,
                  transform: Union[Callable, None],
                  pre_transform: Union[Callable, None],
-                 target_filter: Union[Dict[str, str], None]
+                 target_filter: Union[Dict[str, str], None],
+                 check_integrity: bool
     ):
         """
         Parent class of :class:`GridDataset` and :class:`GraphDataset` which inherits from :class:`torch_geometric.data.dataset.Dataset`.
@@ -55,17 +56,16 @@ class DeeprankDataset(Dataset):
         self.subset = subset
 
         self.target_filter = target_filter
+        
+        if check_integrity:
+            self._check_hdf5_files()
 
-        self._check_hdf5_files()
         self._check_task_and_classes(task, classes)
 
         # create the indexing system
         # alows to associate each mol to an index
         # and get fname and mol name from the index
         self._create_index_entries()
-
-        # get the device
-        self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     def _check_hdf5_files(self):
         """Checks if the data contained in the .HDF5 file is valid."""
@@ -227,6 +227,7 @@ class GridDataset(DeeprankDataset):
         pre_transform: Optional[Callable] = None,
         target_transform: Optional[bool] = False,
         target_filter: Optional[Dict[str, str]] = None,
+        check_integrity: bool = True
     ):
         """
         Class to load the .HDF5 files data into grids.
@@ -267,8 +268,11 @@ class GridDataset(DeeprankDataset):
                 
             target_filter (Dict[str, str], optional): Dictionary of type [target: cond] to filter the molecules.
                 Note that the you can filter on a different target than the one selected as the dataset target. Defaults to None.
+
+            check_integrity (bool, optional): Whether to check the integrity of the hdf5 files.
+                Defaults to True.
         """
-        super().__init__(hdf5_path, subset, target, task, classes, tqdm, root, transform, pre_transform, target_filter)
+        super().__init__(hdf5_path, subset, target, task, classes, tqdm, root, transform, pre_transform, target_filter, check_integrity)
 
         self.features = features
 
@@ -373,8 +377,8 @@ class GridDataset(DeeprankDataset):
             target_value = entry_group[targets.VALUES][self.target][()]
 
         # Wrap up the data in this object, for the collate_fn to handle it properly:
-        data = Data(x=torch.tensor([feature_data], dtype=torch.float).to(self.device),
-                    y=torch.tensor([target_value], dtype=torch.float).to(self.device))
+        data = Data(x=torch.tensor([feature_data], dtype=torch.float),
+                    y=torch.tensor([target_value], dtype=torch.float))
 
         data.entry_names = [entry_name]
 
@@ -390,7 +394,7 @@ class GraphDataset(DeeprankDataset):
         task: Optional[str] = None,
         node_features: Optional[Union[List[str], str]] = "all",
         edge_features: Optional[Union[List[str], str]] = "all",
-        clustering_method: Optional[str] = "mcl",
+        clustering_method: Optional[str] = None,
         classes: Optional[Union[List[str], List[int], List[float]]] = None,
         tqdm: Optional[bool] = True,
         root: Optional[str] = "./",
@@ -399,6 +403,7 @@ class GraphDataset(DeeprankDataset):
         edge_features_transform: Optional[Callable] = lambda x: np.tanh(-x / 2 + 2) + 1,
         target_transform: Optional[bool] = False,
         target_filter: Optional[Dict[str, str]] = None,
+        check_integrity: bool = True
     ):
         """
         Class to load the .HDF5 files data into graphs.
@@ -454,8 +459,11 @@ class GraphDataset(DeeprankDataset):
 
             target_filter (Dict[str, str], optional): Dictionary of type [target: cond] to filter the molecules.
                 Note that the you can filter on a different target than the one selected as the dataset target. Defaults to None.
+
+            check_integrity (bool, optional): Whether to check the integrity of the hdf5 files.
+                Defaults to True.
         """
-        super().__init__(hdf5_path, subset, target, task, classes, tqdm, root, transform, pre_transform, target_filter)
+        super().__init__(hdf5_path, subset, target, task, classes, tqdm, root, transform, pre_transform, target_filter, check_integrity)
 
         self.node_features = node_features
         self.edge_features = edge_features
@@ -503,7 +511,7 @@ class GraphDataset(DeeprankDataset):
                     if vals.ndim == 1:
                         vals = vals.reshape(-1, 1)
                     node_data += (vals,)
-            x = torch.tensor(np.hstack(node_data), dtype=torch.float).to(self.device)
+            x = torch.tensor(np.hstack(node_data), dtype=torch.float)
 
             # edge index,
             # we have to have all the edges i.e : (i,j) and (j,i)
@@ -514,7 +522,6 @@ class GraphDataset(DeeprankDataset):
                 edge_index = torch.tensor(ind, dtype=torch.long).contiguous()
             else:
                 edge_index = torch.empty((2, 0), dtype=torch.long)
-            edge_index = edge_index.to(self.device)
 
             # edge feature
             # we have to have all the edges i.e : (i,j) and (j,i)
@@ -534,14 +541,13 @@ class GraphDataset(DeeprankDataset):
                 edge_attr = torch.tensor(edge_data, dtype=torch.float).contiguous()
             else:
                 edge_attr = torch.empty((edge_index.shape[1], 0), dtype=torch.float).contiguous()
-            edge_attr = edge_attr.to(self.device)
 
             # target
             if self.target is None:
                 y = None
             else:
                 if targets.VALUES in grp and self.target in grp[targets.VALUES]:
-                    y = torch.tensor([grp[f"{targets.VALUES}/{self.target}"][()]], dtype=torch.float).contiguous().to(self.device)
+                    y = torch.tensor([grp[f"{targets.VALUES}/{self.target}"][()]], dtype=torch.float).contiguous()
 
                     if self.task == targets.REGRESS and self.target_transform is True:
                         y = torch.sigmoid(torch.log(y))
@@ -554,7 +560,7 @@ class GraphDataset(DeeprankDataset):
                                      "\n Use the query class to add more target values to input data.")
 
             # positions
-            pos = torch.tensor(grp[f"{Nfeat.NODE}/{Nfeat.POSITION}/"][()], dtype=torch.float).contiguous().to(self.device)
+            pos = torch.tensor(grp[f"{Nfeat.NODE}/{Nfeat.POSITION}/"][()], dtype=torch.float).contiguous()
 
             # cluster
             cluster0 = None
@@ -568,15 +574,13 @@ class GraphDataset(DeeprankDataset):
                             ):
 
                             cluster0 = torch.tensor(
-                                grp["clustering/" + self.clustering_method + "/depth_0"][()], dtype=torch.long).to(self.device)
+                                grp["clustering/" + self.clustering_method + "/depth_0"][()], dtype=torch.long)
                             cluster1 = torch.tensor(
-                                grp["clustering/" + self.clustering_method + "/depth_1"][()], dtype=torch.long).to(self.device)
+                                grp["clustering/" + self.clustering_method + "/depth_1"][()], dtype=torch.long)
                         else:
                             _log.warning("no clusters detected")
                     else:
                         _log.warning(f"no clustering/{self.clustering_method} detected")
-                else:
-                    _log.warning("no clustering group found")
 
         # load
         data = Data(x=x, edge_index=edge_index, edge_attr=edge_attr, y=y, pos=pos)

--- a/deeprankcore/trainer.py
+++ b/deeprankcore/trainer.py
@@ -743,7 +743,7 @@ class Trainer():
             # of class indices with type long and the output should have raw, unnormalized values
             target = torch.tensor(
                 [self.classes_to_index[x] if isinstance(x, str) else self.classes_to_index[int(x)] for x in target]
-            ).to(self.device)
+            )
 
         elif self.task == targets.REGRESS:
             pred = pred.reshape(-1)

--- a/deeprankcore/trainer.py
+++ b/deeprankcore/trainer.py
@@ -619,7 +619,8 @@ class Trainer():
         entry_names = []
         t0 = time()
         for data_batch in self.train_loader:
-            data_batch = data_batch.to(self.device)
+            if self.cuda:
+                data_batch = data_batch.to(self.device, non_blocking=True)
             self.optimizer.zero_grad()
             pred = self.model(data_batch)
             pred, data_batch.y = self._format_output(pred, data_batch.y)
@@ -630,7 +631,7 @@ class Trainer():
 
             # convert mean back to sum
             sum_of_losses += loss_.detach().item() * pred.detach().shape[0]
-            target_vals += data_batch.y.detach().tolist()
+            target_vals += data_batch.y.detach().cpu().numpy().tolist()
 
             # Get the outputs for export
             # Remember that non-linear activation is automatically applied in CrossEntropyLoss
@@ -638,7 +639,7 @@ class Trainer():
                 pred = F.softmax(pred.detach(), dim=1)
             else:
                 pred = pred.detach().reshape(-1)
-            outputs += pred.tolist()
+            outputs += pred.cpu().numpy().tolist()
 
             # Get the name
             entry_names += data_batch.entry_names
@@ -684,7 +685,8 @@ class Trainer():
         count_predictions = 0
         t0 = time()
         for data_batch in loader:
-            data_batch = data_batch.to(self.device)
+            if self.cuda:
+                data_batch = data_batch.to(self.device, non_blocking=True)
             pred = self.model(data_batch)
             pred, y = self._format_output(pred, data_batch.y)
 
@@ -791,8 +793,7 @@ class Trainer():
         Loads the parameters of a pretrained model
         """
 
-        state = torch.load(self.pretrained_model_path,
-                           map_location=torch.device(self.device))
+        state = torch.load(self.pretrained_model_path)
 
         self.target = state["target"]
         self.batch_size_train = state["batch_size_train"]

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -388,12 +388,13 @@ class TestTrainer(unittest.TestCase):
         dataset = GraphDataset(
             hdf5_path="tests/data/hdf5/test.hdf5",
             target=targets.BINARY,
+            clustering_method = "mcl"
         )
 
         trainer = Trainer(
             neuralnet = GINet,
             dataset_train = dataset,
-            val_size = 0,
+            val_size = 0
         )
         trainer.train(batch_size=1)
 


### PR DESCRIPTION
This PR:
- Fixes `num_workers` parameter usage of Dataloader, which allows to load data in parallel on multiple CPUs. Data are initially loaded to CPUs only, to allow such parallelization and to let the user use `num_workers`.
- Improves the handling of the cuda device, transferring data to GPU only during training (tested and working on Snellius).
- Makes facultative doing the checks on the hdf5 files that can take long times in case of bigger datasets, and do not need to be repeated in each experiment.
- Defaults the clustering method to None (again, don't know why it was defaulted to mcl again).