### PR TITLE
feat: center the grids as in the old deeprank

### DIFF
--- a/deeprankcore/molstruct/residue.py
+++ b/deeprankcore/molstruct/residue.py
@@ -89,3 +89,25 @@ class Residue:
     @property
     def position(self) -> np.array:
         return np.mean([atom.position for atom in self._atoms], axis=0)
+
+
+def get_residue_center(residue: Residue) -> np.ndarray:
+    """
+    Chooses a center position for a residue, based on the atoms it has:
+    1. find beta carbon, if present
+    2. find alpha carbon, if present
+    3. else take the mean of the atom positions
+    """
+
+    betas = [atom for atom in residue.atoms if atom.name == "CB"]
+    if len(betas) > 0:
+        return betas[0].position
+
+    alphas = [atom for atom in residue.atoms if atom.name == "CA"]
+    if len(alphas) > 0:
+        return alphas[0].position
+
+    if len(residue.atoms) == 0:
+        raise ValueError(f"cannot get the center position from {residue}, because it has no atoms")
+
+    return np.mean([atom.position for atom in residue.atoms], axis=0)

--- a/deeprankcore/query.py
+++ b/deeprankcore/query.py
@@ -18,7 +18,6 @@ from deeprankcore.utils.grid import GridSettings, MapMethod
 from deeprankcore.molstruct.aminoacid import AminoAcid
 from deeprankcore.molstruct.residue import get_residue_center
 from deeprankcore.utils.buildgraph import (
-    get_residue_contact_pairs,
     get_contact_atoms,
     get_surrounding_residues,
     get_structure,

--- a/deeprankcore/utils/graph.py
+++ b/deeprankcore/utils/graph.py
@@ -220,7 +220,7 @@ class Graph:
         self, hdf5_path: str, settings: GridSettings, method: MapMethod
     ) -> str:
 
-        grid = Grid(self.id, self.center, settings)
+        grid = Grid(self.id, self.center.tolist(), settings)
 
         self.map_to_grid(grid, method)
         grid.to_hdf5(hdf5_path)

--- a/deeprankcore/utils/grid.py
+++ b/deeprankcore/utils/grid.py
@@ -65,14 +65,14 @@ class Grid:
     - feature values on each point
     """
 
-    def __init__(self, id_: str, center: np.ndarray, settings: GridSettings):
+    def __init__(self, id_: str, center: List[float], settings: GridSettings):
         self.id = id_
 
-        self._center = center
+        self._center = np.array(center)
 
         self._settings = settings
 
-        self._set_mesh(center, settings)
+        self._set_mesh(self._center, settings)
 
         self._features = {}
 

--- a/deeprankcore/utils/grid.py
+++ b/deeprankcore/utils/grid.py
@@ -36,21 +36,14 @@ class GridSettings:
 
     def __init__(
         self,
-        center: List[float],
         points_counts: List[int],
         sizes: List[float]
     ):
-        assert len(center) == 3
         assert len(points_counts) == 3
         assert len(sizes) == 3
 
-        self._center = center
         self._points_counts = points_counts
         self._sizes = sizes
-
-    @property
-    def center(self) -> List[float]:
-        return self._center
 
     @property
     def resolutions(self) -> List[float]:
@@ -72,37 +65,43 @@ class Grid:
     - feature values on each point
     """
 
-    def __init__(self, id_: str, settings: GridSettings):
+    def __init__(self, id_: str, center: np.ndarray, settings: GridSettings):
         self.id = id_
+
+        self._center = center
 
         self._settings = settings
 
-        self._set_mesh(settings)
+        self._set_mesh(center, settings)
 
         self._features = {}
 
-    def _set_mesh(self, settings: GridSettings):
+    def _set_mesh(self, center: np.ndarray, settings: GridSettings):
         "builds the grid points"
 
         half_size_x = settings.sizes[0] / 2
         half_size_y = settings.sizes[1] / 2
         half_size_z = settings.sizes[2] / 2
 
-        min_x = settings.center[0] - half_size_x
+        min_x = center[0] - half_size_x
         max_x = min_x + (settings.points_counts[0] - 1.0) * settings.resolutions[0]
         self._xs = np.linspace(min_x, max_x, num=settings.points_counts[0])
 
-        min_y = settings.center[1] - half_size_y
+        min_y = center[1] - half_size_y
         max_y = min_y + (settings.points_counts[1] - 1.0) * settings.resolutions[1]
         self._ys = np.linspace(min_y, max_y, num=settings.points_counts[1])
 
-        min_z = settings.center[2] - half_size_z
+        min_z = center[2] - half_size_z
         max_z = min_z + (settings.points_counts[2] - 1.0) * settings.resolutions[2]
         self._zs = np.linspace(min_z, max_z, num=settings.points_counts[2])
 
         self._ygrid, self._xgrid, self._zgrid = np.meshgrid(
             self._ys, self._xs, self._zs
         )
+
+    @property
+    def center(self) -> np.ndarray:
+        return self._center
 
     @property
     def xs(self) -> np.array:
@@ -127,10 +126,6 @@ class Grid:
     @property
     def zgrid(self) -> np.array:
         return self._zgrid
-
-    @property
-    def center(self) -> np.array:
-        return self._settings.center
 
     @property
     def features(self) -> Dict[str, np.array]:
@@ -234,7 +229,7 @@ class Grid:
 
         return neighbour_data
 
-    def _get_atomic_density_koes(self, center: np.ndarray, vanderwaals_radius: float) -> np.ndarray:
+    def _get_atomic_density_koes(self, position, vanderwaals_radius: float) -> np.ndarray:
         """
         Function to map individual atomic density on the grid.
         The formula is equation (1) of the Koes paper
@@ -244,9 +239,9 @@ class Grid:
             the mapped density
         """
 
-        distances = np.sqrt(np.square(self.xgrid - center[0]) +
-                            np.square(self.ygrid - center[1]) +
-                            np.square(self.zgrid - center[2]))
+        distances = np.sqrt(np.square(self.xgrid - position[0]) +
+                            np.square(self.ygrid - position[1]) +
+                            np.square(self.zgrid - position[2]))
 
         density_data = np.zeros(distances.shape)
 

--- a/deeprankcore/utils/grid.py
+++ b/deeprankcore/utils/grid.py
@@ -229,7 +229,7 @@ class Grid:
 
         return neighbour_data
 
-    def _get_atomic_density_koes(self, position, vanderwaals_radius: float) -> np.ndarray:
+    def _get_atomic_density_koes(self, position: np.ndarray, vanderwaals_radius: float) -> np.ndarray:
         """
         Function to map individual atomic density on the grid.
         The formula is equation (1) of the Koes paper

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -54,7 +54,7 @@ def test_integration_cnn(): # pylint: disable=too-many-locals
             queries.add(query)
 
         hdf5_paths = queries.process(prefix = prefix,
-                                     grid_settings=GridSettings([100.0, 50.0, 50.0], [20, 20, 20], [20.0, 20.0, 20.0]),
+                                     grid_settings=GridSettings([20, 20, 20], [20.0, 20.0, 20.0]),
                                      grid_map_method=MapMethod.GAUSSIAN)
         assert len(hdf5_paths) > 0
 

--- a/tests/utils/test_graph.py
+++ b/tests/utils/test_graph.py
@@ -62,7 +62,7 @@ def test_graph_build_and_export(): # pylint: disable=too-many-locals
 
         # export grid to hdf5
         grid_settings = GridSettings([20, 21, 21], [20.0, 21.0, 21.0])
-        assert np.all(grid_settings.resolutions == np.array((1.0, 1.0, 1.0))
+        assert np.all(grid_settings.resolutions == np.array((1.0, 1.0, 1.0)))
 
         graph.write_as_grid_to_hdf5(hdf5_path, grid_settings, MapMethod.FAST_GAUSSIAN)
 
@@ -97,6 +97,6 @@ def test_graph_build_and_export(): # pylint: disable=too-many-locals
                 assert "value" in mapped_group[feature_name]
                 data = mapped_group[feature_name]["value"][()]
                 assert len(np.nonzero(data)) > 0, f"{feature_name}: all zero"
-                assert np.all(data.shape == grid_settings.points_counts)
+                assert np.all(data.shape == tuple(grid_settings.points_counts))
     finally:
         shutil.rmtree(tmp_dir_path)  # clean up after the test

--- a/tests/utils/test_graph.py
+++ b/tests/utils/test_graph.py
@@ -61,7 +61,7 @@ def test_graph_build_and_export(): # pylint: disable=too-many-locals
         graph.write_to_hdf5(hdf5_path)
 
         # export grid to hdf5
-        grid_settings = GridSettings(np.array((0, 0, 0)), np.array((20, 21, 21)), np.array((20.0, 21.0, 21.0)))
+        grid_settings = GridSettings(np.array((20, 21, 21)), np.array((20.0, 21.0, 21.0)))
         assert np.all(grid_settings.resolutions == np.array((1.0, 1.0, 1.0)))
 
         graph.write_as_grid_to_hdf5(hdf5_path, grid_settings, MapMethod.FAST_GAUSSIAN)

--- a/tests/utils/test_graph.py
+++ b/tests/utils/test_graph.py
@@ -61,8 +61,8 @@ def test_graph_build_and_export(): # pylint: disable=too-many-locals
         graph.write_to_hdf5(hdf5_path)
 
         # export grid to hdf5
-        grid_settings = GridSettings(np.array((20, 21, 21)), np.array((20.0, 21.0, 21.0)))
-        assert np.all(grid_settings.resolutions == np.array((1.0, 1.0, 1.0)))
+        grid_settings = GridSettings([20, 21, 21], [20.0, 21.0, 21.0])
+        assert np.all(grid_settings.resolutions == np.array((1.0, 1.0, 1.0))
 
         graph.write_as_grid_to_hdf5(hdf5_path, grid_settings, MapMethod.FAST_GAUSSIAN)
 

--- a/tests/utils/test_grid.py
+++ b/tests/utils/test_grid.py
@@ -8,7 +8,6 @@ import deeprankcore.features.contact
 import deeprankcore.features.surfacearea
 from deeprankcore.utils.grid import MapMethod, GridSettings, Grid
 from deeprankcore.molstruct.atom import AtomicElement
-from deeprankcore.domain.nodestorage import POSITION as POSITION_FEATURE
 
 
 def _inflate(index: np.array, value: np.array, shape: List[int]):

--- a/tests/utils/test_grid.py
+++ b/tests/utils/test_grid.py
@@ -86,8 +86,6 @@ def test_atomic_grid_orientation():
     graph = query.build([deeprankcore.features.contact])
 
     # Get atomic positions from the graph
-    positions = np.array([node.features[POSITION_FEATURE] for node in graph.nodes])
-
     chain1_carbon_positions = [node.id.position  # the node id is actually the atom
                                for node in graph.nodes
                                if node.id.residue.chain.id == chain_id1 and


### PR DESCRIPTION
Grids must be given a center position on creation.

With this modification, the query object assigns a center position to the graph objects. For single residue variant graphs, this is the variant residue position. For protein-protein interaction graphs, this is the mean of the contacting atom positions.

When the graph is converted into a grid, this center position is passed on and it will determine the position of the grid points.

A test has been added to check that the center position is the same as in the original deeprank.
