### PR TITLE
refactor: delete all outputs from unit tests after run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ dist/*
 *.lzone
 *.ref_pairs
 
-# hdf5
+# hdf5 and tar
 *.hdf5
 *.tar
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,7 +15,6 @@ from deeprankcore.tools.target import compute_targets
 from deeprankcore.domain import (edgestorage as Efeat, nodestorage as Nfeat,
                                 targetstorage as targets)
 
-model_path = './tests/test.pth.tar'
 
 def test_integration_cnn(): # pylint: disable=too-many-locals
     """
@@ -33,6 +32,7 @@ def test_integration_cnn(): # pylint: disable=too-many-locals
 
     hdf5_directory = mkdtemp()
     output_directory = mkdtemp()
+    model_path = output_directory + 'test.pth.tar'
 
     prefix = os.path.join(hdf5_directory, "test-queries-process")
 
@@ -124,6 +124,7 @@ def test_integration_gnn(): # pylint: disable=too-many-locals
 
     hdf5_directory = mkdtemp()
     output_directory = mkdtemp()
+    model_path = output_directory + 'test.pth.tar'
 
     prefix = os.path.join(hdf5_directory, "test-queries-process")
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -171,11 +171,9 @@ class TestTrainer(unittest.TestCase):
             )
 
     def test_ginet_sigmoid(self):
-        try:
-            f = glob.glob(self.work_directory + '/*')[0]
+        files = glob.glob(self.work_directory + '/*')
+        for f in files:
             os.remove(f)
-        except IndexError:
-            pass
         assert len(os.listdir(self.work_directory)) == 0
 
         _model_base_test(
@@ -195,11 +193,9 @@ class TestTrainer(unittest.TestCase):
         assert len(os.listdir(self.work_directory)) > 0
 
     def test_ginet(self):
-        try:
-            f = glob.glob(self.work_directory + '/*')[0]
+        files = glob.glob(self.work_directory + '/*')
+        for f in files:
             os.remove(f)
-        except IndexError:
-            pass
         assert len(os.listdir(self.work_directory)) == 0
         
         _model_base_test(
@@ -219,11 +215,9 @@ class TestTrainer(unittest.TestCase):
         assert len(os.listdir(self.work_directory)) > 0
 
     def test_ginet_class(self):
-        try:
-            f = glob.glob(self.work_directory + '/*')[0]
+        files = glob.glob(self.work_directory + '/*')
+        for f in files:
             os.remove(f)
-        except IndexError:
-            pass
         assert len(os.listdir(self.work_directory)) == 0
 
         _model_base_test(
@@ -244,11 +238,9 @@ class TestTrainer(unittest.TestCase):
         assert len(os.listdir(self.work_directory)) > 0
 
     def test_fout(self):
-        try:
-            f = glob.glob(self.work_directory + '/*')[0]
+        files = glob.glob(self.work_directory + '/*')
+        for f in files:
             os.remove(f)
-        except IndexError:
-            pass
         assert len(os.listdir(self.work_directory)) == 0
 
         _model_base_test(
@@ -262,17 +254,15 @@ class TestTrainer(unittest.TestCase):
             targets.CLASSIF,
             targets.BINARY,
             False,
-            None,
+            [HDF5OutputExporter(self.work_directory)],
             "mcl",
         )
         assert len(os.listdir(self.work_directory)) > 0
 
     def test_sgat(self):
-        try:
-            f = glob.glob(self.work_directory + '/*')[0]
+        files = glob.glob(self.work_directory + '/*')
+        for f in files:
             os.remove(f)
-        except IndexError:
-            pass
         assert len(os.listdir(self.work_directory)) == 0
 
         _model_base_test(
@@ -286,17 +276,15 @@ class TestTrainer(unittest.TestCase):
             targets.REGRESS,
             targets.IRMSD,
             False,
-            None,
+            [HDF5OutputExporter(self.work_directory)],
             "mcl",
         )
         assert len(os.listdir(self.work_directory)) > 0
 
     def test_naive(self):
-        try:
-            f = glob.glob(self.work_directory + '/*')[0]
+        files = glob.glob(self.work_directory + '/*')
+        for f in files:
             os.remove(f)
-        except IndexError:
-            pass
         assert len(os.listdir(self.work_directory)) == 0
 
         _model_base_test(
@@ -313,7 +301,7 @@ class TestTrainer(unittest.TestCase):
             [HDF5OutputExporter(self.work_directory)],
             "mcl",
         )
-        assert len(os.listdir(self.work_directory)) >0
+        assert len(os.listdir(self.work_directory)) > 0
 
     def test_incompatible_regression(self):
         with pytest.raises(ValueError):
@@ -497,11 +485,9 @@ class TestTrainer(unittest.TestCase):
 
     def test_cuda(self):    # test_ginet, but with cuda
         if torch.cuda.is_available():
-            try:
-                f = glob.glob(self.work_directory + '/*')[0]
+            files = glob.glob(self.work_directory + '/*')
+            for f in files:
                 os.remove(f)
-            except IndexError:
-                pass
             assert len(os.listdir(self.work_directory)) == 0
 
             _model_base_test(

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -124,43 +124,51 @@ class TestTrainer(unittest.TestCase):
         shutil.rmtree(class_.work_directory)
 
     def test_grid_regression(self):
-        dataset = GridDataset(hdf5_path="tests/data/hdf5/1ATN_ppi.hdf5",
-                              subset=None,
-                              target=targets.IRMSD,
-                              task=targets.REGRESS,
-                              features=[Efeat.VANDERWAALS])
-
-        trainer = Trainer(CnnRegression, dataset)
-
+        dataset = GridDataset(
+            hdf5_path="tests/data/hdf5/1ATN_ppi.hdf5",
+            subset=None,
+            target=targets.IRMSD,
+            task=targets.REGRESS,
+            features=[Efeat.VANDERWAALS]
+        )
+        trainer = Trainer(
+            CnnRegression,
+            dataset
+        )
         trainer.train(nepoch=1, batch_size=2, save_best_model=None)
 
     def test_grid_classification(self):
-        dataset = GridDataset(hdf5_path="tests/data/hdf5/1ATN_ppi.hdf5",
-                              subset=None,
-                              target=targets.BINARY,
-                              task=targets.CLASSIF,
-                              features=[Efeat.VANDERWAALS])
-
-        trainer = Trainer(CnnClassification, dataset)
-
+        dataset = GridDataset(
+            hdf5_path="tests/data/hdf5/1ATN_ppi.hdf5",
+            subset=None,
+            target=targets.BINARY,
+            task=targets.CLASSIF,
+            features=[Efeat.VANDERWAALS])
+        trainer = Trainer(
+            CnnClassification,
+            dataset
+        )
         trainer.train(nepoch=1, batch_size = 2, save_best_model=None)
 
     def test_grid_graph_incompatible(self):
-        dataset_train = GridDataset(hdf5_path="tests/data/hdf5/1ATN_ppi.hdf5",
-                                    subset=None,
-                                    target=targets.BINARY,
-                                    task=targets.CLASSIF,
-                                    features=[Efeat.VANDERWAALS])
-
+        dataset_train = GridDataset(
+            hdf5_path="tests/data/hdf5/1ATN_ppi.hdf5",
+            subset=None,
+            target=targets.BINARY,
+            task=targets.CLASSIF,
+            features=[Efeat.VANDERWAALS]
+        )
         dataset_valid = GraphDataset(
-                hdf5_path="tests/data/hdf5/valid.hdf5",
-                target=targets.BINARY,
-            )
+            hdf5_path="tests/data/hdf5/valid.hdf5",
+            target=targets.BINARY,
+        )
 
         with pytest.raises(TypeError):
-            Trainer(CnnClassification,
-                    dataset_train=dataset_train,
-                    dataset_val=dataset_valid)
+            Trainer(
+                CnnClassification,
+                dataset_train=dataset_train,
+                dataset_val=dataset_valid
+            )
 
     def test_ginet_sigmoid(self):
         try:
@@ -343,12 +351,10 @@ class TestTrainer(unittest.TestCase):
 
     def test_incompatible_no_pretrained_no_train(self):
         with pytest.raises(ValueError):
-
             dataset = GraphDataset(
                 hdf5_path="tests/data/hdf5/test.hdf5",
                 target=targets.BINARY,
             )
-
             Trainer(
                 neuralnet = NaiveNetwork,
                 dataset_test = dataset,
@@ -359,7 +365,6 @@ class TestTrainer(unittest.TestCase):
             dataset = GraphDataset(
                 hdf5_path="tests/data/hdf5/test.hdf5",
             )
-
             Trainer(
                 neuralnet = NaiveNetwork,
                 dataset_train = dataset,
@@ -371,7 +376,6 @@ class TestTrainer(unittest.TestCase):
                 hdf5_path="tests/data/hdf5/test.hdf5",
                 target=targets.BINARY,
             )
-
             Trainer(
                 dataset_train = dataset,
             )
@@ -383,7 +387,6 @@ class TestTrainer(unittest.TestCase):
                 target=targets.BINARY,
                 clustering_method="mcl"
             )
-
             trainer = Trainer(
                 neuralnet = GINet,
                 dataset_train = dataset,
@@ -392,11 +395,11 @@ class TestTrainer(unittest.TestCase):
             with warnings.catch_warnings(record=UserWarning):
                 trainer.train(nepoch=3, validate=True, save_best_model=None)
                 trainer.save_model(self.save_path)
-
                 Trainer(
                     neuralnet = GINet,
                     dataset_train = dataset,
-                    pretrained_model=self.save_path)
+                    pretrained_model=self.save_path
+                )
 
     def test_incompatible_pretrained_no_Net(self):
         with pytest.raises(ValueError):
@@ -405,7 +408,6 @@ class TestTrainer(unittest.TestCase):
                 target=targets.BINARY,
                 clustering_method="mcl"
             )
-
             trainer = Trainer(
                 neuralnet = GINet,
                 dataset_train = dataset,
@@ -414,53 +416,45 @@ class TestTrainer(unittest.TestCase):
             with warnings.catch_warnings(record=UserWarning):
                 trainer.train(nepoch=3, validate=True, save_best_model=None)
                 trainer.save_model(self.save_path)
-
                 Trainer(
                     dataset_test = dataset,
-                    pretrained_model=self.save_path)
+                    pretrained_model=self.save_path
+                )
 
     def test_no_valid_provided(self):
-
         dataset = GraphDataset(
             hdf5_path="tests/data/hdf5/test.hdf5",
             target=targets.BINARY,
             clustering_method="mcl"
         )
-
         trainer = Trainer(
             neuralnet = GINet,
             dataset_train = dataset,
         )
         trainer.train(batch_size = 1, save_best_model=None)
-
         assert len(trainer.train_loader) == int(0.75 * len(dataset))
         assert len(trainer.valid_loader) == int(0.25 * len(dataset))
 
     def test_no_valid_full_train(self):
-
         dataset = GraphDataset(
             hdf5_path="tests/data/hdf5/test.hdf5",
             target=targets.BINARY,
             clustering_method = "mcl"
         )
-
         trainer = Trainer(
             neuralnet = GINet,
             dataset_train = dataset,
             val_size = 0
         )
         trainer.train(batch_size=1, save_best_model=None)
-
         assert len(trainer.train_loader) == len(dataset)
         assert trainer.valid_loader is None
 
     def test_optim(self):
-
         dataset = GraphDataset(
             hdf5_path="tests/data/hdf5/test.hdf5",
             target=targets.BINARY,
         )
-
         trainer = Trainer(
             neuralnet = NaiveNetwork,
             dataset_train = dataset,
@@ -469,7 +463,6 @@ class TestTrainer(unittest.TestCase):
         optimizer = torch.optim.Adamax
         lr = 0.1
         weight_decay = 1e-04
-
         trainer.configure_optimizers(optimizer, lr, weight_decay)
 
         assert isinstance(trainer.optimizer, optimizer)
@@ -479,7 +472,6 @@ class TestTrainer(unittest.TestCase):
         with warnings.catch_warnings(record=UserWarning):
             trainer.train(nepoch=3, save_best_model=None)
             trainer.save_model(self.save_path)
-
             trainer_pretrained = Trainer(
                 neuralnet = NaiveNetwork,
                 dataset_test=dataset,
@@ -490,12 +482,10 @@ class TestTrainer(unittest.TestCase):
         assert trainer_pretrained.weight_decay == weight_decay
 
     def test_default_optim(self):
-
         dataset = GraphDataset(
             hdf5_path="tests/data/hdf5/test.hdf5",
             target=targets.BINARY,
         )
-
         trainer = Trainer(
             neuralnet = NaiveNetwork,
             dataset_train = dataset,
@@ -542,13 +532,11 @@ class TestTrainer(unittest.TestCase):
                 target=targets.BINARY,
                 edge_features=[Efeat.DISTANCE, Efeat.COVALENT]
             )
-            
             dataset_val = GraphDataset(
                 hdf5_path="tests/data/hdf5/test.hdf5",
                 target=targets.BINARY,
                 edge_features=[Efeat.DISTANCE]
             )
-
             Trainer(
                 neuralnet = GINet,
                 dataset_train = dataset_train,
@@ -563,14 +551,12 @@ class TestTrainer(unittest.TestCase):
                 edge_features=[Efeat.DISTANCE, Efeat.COVALENT],
                 clustering_method="mcl"
             )
-            
             dataset_test = GraphDataset(
                 hdf5_path="tests/data/hdf5/test.hdf5",
                 target=targets.BINARY,
                 edge_features=[Efeat.DISTANCE],
                 clustering_method="mcl"
             )
-
             trainer = Trainer(
                 neuralnet = GINet,
                 dataset_train = dataset_train,
@@ -579,12 +565,12 @@ class TestTrainer(unittest.TestCase):
             with warnings.catch_warnings(record=UserWarning):
                 trainer.train(nepoch=3, validate=True, save_best_model=None)
                 trainer.save_model(self.save_path)
-
                 Trainer(
                     neuralnet = GINet,
                     dataset_train = dataset_train,
                     dataset_test = dataset_test,
-                    pretrained_model=self.save_path)
+                    pretrained_model=self.save_path
+                )
 
     def test_trainsize(self):
         hdf5 = "tests/data/hdf5/train.hdf5"
@@ -598,7 +584,6 @@ class TestTrainer(unittest.TestCase):
                 dataset = GraphDataset(hdf5_path=hdf5),
                 splitsize=t,
             )
-
             assert len(dataset_train) == n_train
             assert len(dataset_val) == n_val
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -532,8 +532,8 @@ class TestTrainer(unittest.TestCase):
             assert len(os.listdir(self.work_directory)) > 0
 
         else:
-            warnings.warn("CUDA is not available. test_cuda skipped")
-            _log.debug("CUDA is not available, test_cuda skipped")
+            warnings.warn("CUDA is not available; test_cuda was skipped")
+            _log.warn("CUDA is not available; test_cuda was skipped")
 
     def test_dataset_equivalence_no_pretrained(self):
         with pytest.raises(ValueError):
@@ -627,20 +627,10 @@ class TestTrainer(unittest.TestCase):
     def test_invalid_cuda_ngpus(self):
         dataset_train = GraphDataset(
             hdf5_path="tests/data/hdf5/test.hdf5"
-        )
-        
+        )            
         dataset_val = GraphDataset(
             hdf5_path="tests/data/hdf5/test.hdf5"
         )
-
-        if not torch.cuda.is_available():
-            with pytest.raises(ValueError):
-                Trainer(
-                    neuralnet = GINet,
-                    dataset_train = dataset_train,
-                    dataset_val = dataset_val,
-                    cuda = True
-                )
 
         with pytest.raises(ValueError):
             Trainer(
@@ -649,6 +639,29 @@ class TestTrainer(unittest.TestCase):
                 dataset_val = dataset_val,
                 ngpu = 2
             )
+
+    def test_invalid_no_cuda_available(self):
+        if not torch.cuda.is_available():
+            dataset_train = GraphDataset(
+                hdf5_path="tests/data/hdf5/test.hdf5"
+            )            
+            dataset_val = GraphDataset(
+                hdf5_path="tests/data/hdf5/test.hdf5"
+            )
+
+            with pytest.raises(ValueError):
+                Trainer(
+                    neuralnet = GINet,
+                    dataset_train = dataset_train,
+                    dataset_val = dataset_val,
+                    cuda = True
+                )
+        
+        else:
+            warnings.warn('CUDA is available; test_invalid_no_cuda_available was skipped')
+            _log.warn('CUDA is available; test_invalid_no_cuda_available was skipped')
+
+
 
 
 if __name__ == "__main__":

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -509,7 +509,7 @@ class TestTrainer(unittest.TestCase):
 
         else:
             warnings.warn("CUDA is not available; test_cuda was skipped")
-            _log.warn("CUDA is not available; test_cuda was skipped")
+            _log.info("CUDA is not available; test_cuda was skipped")
 
     def test_dataset_equivalence_no_pretrained(self):
         with pytest.raises(ValueError):
@@ -630,7 +630,7 @@ class TestTrainer(unittest.TestCase):
         
         else:
             warnings.warn('CUDA is available; test_invalid_no_cuda_available was skipped')
-            _log.warn('CUDA is available; test_invalid_no_cuda_available was skipped')
+            _log.info('CUDA is available; test_invalid_no_cuda_available was skipped')
 
 
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -163,11 +163,6 @@ class TestTrainer(unittest.TestCase):
                     dataset_val=dataset_valid)
 
     def test_ginet_sigmoid(self):
-        try:
-            f = glob.glob(self.work_directory + '/*')[0]
-            os.remove(f)
-        except IndexError:
-            pass
         assert len(os.listdir(self.work_directory)) == 0
 
         _model_base_test(
@@ -186,13 +181,11 @@ class TestTrainer(unittest.TestCase):
         )
 
         assert len(os.listdir(self.work_directory)) > 0
+        f = glob.glob(self.work_directory + '/*')[0]
+        os.remove(f)
+
 
     def test_ginet(self):
-        try:
-            f = glob.glob(self.work_directory + '/*')[0]
-            os.remove(f)
-        except IndexError:
-            pass
         assert len(os.listdir(self.work_directory)) == 0
         
         _model_base_test(
@@ -211,13 +204,10 @@ class TestTrainer(unittest.TestCase):
         )
 
         assert len(os.listdir(self.work_directory)) > 0
+        f = glob.glob(self.work_directory + '/*')[0]
+        os.remove(f)
 
     def test_ginet_class(self):
-        try:
-            f = glob.glob(self.work_directory + '/*')[0]
-            os.remove(f)
-        except IndexError:
-            pass
         assert len(os.listdir(self.work_directory)) == 0
 
         _model_base_test(
@@ -236,6 +226,8 @@ class TestTrainer(unittest.TestCase):
         )
 
         assert len(os.listdir(self.work_directory)) > 0
+        f = glob.glob(self.work_directory + '/*')[0]
+        os.remove(f)
 
     def test_fout(self):
         _model_base_test(
@@ -486,11 +478,6 @@ class TestTrainer(unittest.TestCase):
     def test_cuda(self):    # test_ginet, but with cuda
         if torch.cuda.is_available():
 
-            try:
-                f = glob.glob(self.work_directory + '/*')[0]
-                os.remove(f)
-            except IndexError:
-                pass
             assert len(os.listdir(self.work_directory)) == 0
 
             _model_base_test(
@@ -510,6 +497,8 @@ class TestTrainer(unittest.TestCase):
             )
 
             assert len(os.listdir(self.work_directory)) > 0
+            f = glob.glob(self.work_directory + '/*')[0]
+            os.remove(f)
 
         else:
             warnings.warn("CUDA not available. test_cuda skipped")

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -163,6 +163,11 @@ class TestTrainer(unittest.TestCase):
                     dataset_val=dataset_valid)
 
     def test_ginet_sigmoid(self):
+        try:
+            f = glob.glob(self.work_directory + '/*')[0]
+            os.remove(f)
+        except IndexError:
+            pass
         assert len(os.listdir(self.work_directory)) == 0
 
         _model_base_test(
@@ -179,13 +184,14 @@ class TestTrainer(unittest.TestCase):
             [HDF5OutputExporter(self.work_directory)],
             "mcl",
         )
-
         assert len(os.listdir(self.work_directory)) > 0
-        f = glob.glob(self.work_directory + '/*')[0]
-        os.remove(f)
-
 
     def test_ginet(self):
+        try:
+            f = glob.glob(self.work_directory + '/*')[0]
+            os.remove(f)
+        except IndexError:
+            pass
         assert len(os.listdir(self.work_directory)) == 0
         
         _model_base_test(
@@ -202,12 +208,14 @@ class TestTrainer(unittest.TestCase):
             [HDF5OutputExporter(self.work_directory)],
             "mcl",
         )
-
         assert len(os.listdir(self.work_directory)) > 0
-        f = glob.glob(self.work_directory + '/*')[0]
-        os.remove(f)
 
     def test_ginet_class(self):
+        try:
+            f = glob.glob(self.work_directory + '/*')[0]
+            os.remove(f)
+        except IndexError:
+            pass
         assert len(os.listdir(self.work_directory)) == 0
 
         _model_base_test(
@@ -226,10 +234,15 @@ class TestTrainer(unittest.TestCase):
         )
 
         assert len(os.listdir(self.work_directory)) > 0
-        f = glob.glob(self.work_directory + '/*')[0]
-        os.remove(f)
 
     def test_fout(self):
+        try:
+            f = glob.glob(self.work_directory + '/*')[0]
+            os.remove(f)
+        except IndexError:
+            pass
+        assert len(os.listdir(self.work_directory)) == 0
+
         _model_base_test(
             self.save_path,
             FoutNet,
@@ -244,8 +257,16 @@ class TestTrainer(unittest.TestCase):
             None,
             "mcl",
         )
+        assert len(os.listdir(self.work_directory)) > 0
 
     def test_sgat(self):
+        try:
+            f = glob.glob(self.work_directory + '/*')[0]
+            os.remove(f)
+        except IndexError:
+            pass
+        assert len(os.listdir(self.work_directory)) == 0
+
         _model_base_test(
             self.save_path,
             SGAT,
@@ -260,8 +281,16 @@ class TestTrainer(unittest.TestCase):
             None,
             "mcl",
         )
+        assert len(os.listdir(self.work_directory)) > 0
 
     def test_naive(self):
+        try:
+            f = glob.glob(self.work_directory + '/*')[0]
+            os.remove(f)
+        except IndexError:
+            pass
+        assert len(os.listdir(self.work_directory)) == 0
+
         _model_base_test(
             self.save_path,
             NaiveNetwork,
@@ -276,6 +305,7 @@ class TestTrainer(unittest.TestCase):
             [HDF5OutputExporter(self.work_directory)],
             "mcl",
         )
+        assert len(os.listdir(self.work_directory)) >0
 
     def test_incompatible_regression(self):
         with pytest.raises(ValueError):
@@ -477,7 +507,11 @@ class TestTrainer(unittest.TestCase):
 
     def test_cuda(self):    # test_ginet, but with cuda
         if torch.cuda.is_available():
-
+            try:
+                f = glob.glob(self.work_directory + '/*')[0]
+                os.remove(f)
+            except IndexError:
+                pass
             assert len(os.listdir(self.work_directory)) == 0
 
             _model_base_test(
@@ -495,14 +529,11 @@ class TestTrainer(unittest.TestCase):
                 "mcl",
                 True
             )
-
             assert len(os.listdir(self.work_directory)) > 0
-            f = glob.glob(self.work_directory + '/*')[0]
-            os.remove(f)
 
         else:
-            warnings.warn("CUDA not available. test_cuda skipped")
-            _log.debug("cuda is not available, test_cuda skipped")
+            warnings.warn("CUDA is not available. test_cuda skipped")
+            _log.debug("CUDA is not available, test_cuda skipped")
 
     def test_dataset_equivalence_no_pretrained(self):
         with pytest.raises(ValueError):

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -1,6 +1,7 @@
 import tempfile
 import shutil
 import os
+import glob
 import unittest
 import pytest
 import logging
@@ -161,6 +162,13 @@ class TestTrainer(unittest.TestCase):
                     dataset_val=dataset_valid)
 
     def test_ginet_sigmoid(self):
+        try:
+            f = glob.glob(self.work_directory + '/*')[0]
+            os.remove(f)
+        except IndexError:
+            pass
+        assert len(os.listdir(self.work_directory)) == 0
+
         _model_base_test(
             GINet,
             "tests/data/hdf5/1ATN_ppi.hdf5",
@@ -178,6 +186,13 @@ class TestTrainer(unittest.TestCase):
         assert len(os.listdir(self.work_directory)) > 0
 
     def test_ginet(self):
+        try:
+            f = glob.glob(self.work_directory + '/*')[0]
+            os.remove(f)
+        except IndexError:
+            pass
+        assert len(os.listdir(self.work_directory)) == 0
+        
         _model_base_test(           
             GINet,
             "tests/data/hdf5/1ATN_ppi.hdf5",
@@ -195,6 +210,13 @@ class TestTrainer(unittest.TestCase):
         assert len(os.listdir(self.work_directory)) > 0
 
     def test_ginet_class(self):
+        try:
+            f = glob.glob(self.work_directory + '/*')[0]
+            os.remove(f)
+        except IndexError:
+            pass
+        assert len(os.listdir(self.work_directory)) == 0
+
         _model_base_test(
             GINet,
             "tests/data/hdf5/variants.hdf5",
@@ -454,6 +476,13 @@ class TestTrainer(unittest.TestCase):
 
     def test_cuda(self):    # test_ginet, but with cuda
         if torch.cuda.is_available():
+
+            try:
+                f = glob.glob(self.work_directory + '/*')[0]
+                os.remove(f)
+            except IndexError:
+                pass
+            assert len(os.listdir(self.work_directory)) == 0
 
             _model_base_test(           
                 GINet,


### PR DESCRIPTION
The models created in some of the unit tests were stored inside the repo in a few different places.

Also, the assertion to check for output_exporter in test_trainer was recognizing output from previous unit tests. These are now cleared at the beginning of each test.