### PR TITLE
ci: do not close stale issues or PRs

### DIFF
--- a/.github/workflows/stale_issue_pr.yml
+++ b/.github/workflows/stale_issue_pr.yml
@@ -13,12 +13,12 @@ jobs:
       - uses: actions/stale@v5.0.0
         with:
           days-before-issue-stale: 30
-          days-before-issue-close: 7
+          days-before-issue-close: -1
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 30 days with no activity. Remove stale label or comment or this will be closed in 7 days."
           close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
           days-before-pr-stale: 14
-          days-before-pr-close: 7
+          days-before-pr-close: -1
           stale-pr-message: "This PR is stale because it has been open for 14 days with no activity. Remove stale label or comment or this will be closed in 7 days."
           close-pr-message: "This PR was closed because it has been inactive for 7 days since being marked as stale."
           exempt-issue-labels: 'blocked'


### PR DESCRIPTION
I think we actually want old issues to just stay open, right? Until now, we were constantly removing the stale label. 

I think better to just leave as stale forever, so it's still clear that this is an "old" issue, but not close it until it's done. This way we can occasionally check the stale issues and see whether they have been done in the meantime or whether it is time to pick one up.