### PR TITLE
This will (hopefully) fix the hash circular dependency issue

### DIFF
--- a/deeprankcore/molstruct/atom.py
+++ b/deeprankcore/molstruct/atom.py
@@ -56,7 +56,7 @@ class Atom:
         )
 
     def __hash__(self) -> hash:
-        return hash((self._residue, self._name))
+        return hash((tuple(self._position), self._element, self._name))
 
     def __repr__(self) -> str:
         return f"{self._residue} {self._name}"

--- a/deeprankcore/molstruct/residue.py
+++ b/deeprankcore/molstruct/residue.py
@@ -38,7 +38,7 @@ class Residue:
         )
 
     def __hash__(self) -> hash:
-        return hash((self._chain, self._number, self._insertion_code))
+        return hash((self._number, self._insertion_code))
 
     def get_pssm(self) -> PssmRow:
         """ if the residue's chain has pssm info linked to it,

--- a/deeprankcore/molstruct/structure.py
+++ b/deeprankcore/molstruct/structure.py
@@ -82,10 +82,10 @@ class Chain:
     def add_residue(self, residue):
         self._residues[(residue.number, residue.insertion_code)] = residue
 
-    def has_residue(self, residue_number: int, insertion_code: str) -> bool:
+    def has_residue(self, residue_number: int, insertion_code: Optional[str] = None) -> bool:
         return (residue_number, insertion_code) in self._residues
 
-    def get_residue(self, residue_number: int, insertion_code: str):
+    def get_residue(self, residue_number: int, insertion_code: Optional[str] = None):
         return self._residues[(residue_number, insertion_code)]
 
     @property
@@ -112,7 +112,7 @@ class Chain:
         )
 
     def __hash__(self) -> hash:
-        return hash((self._model, self._id))
+        return hash(self._id)
 
     def __repr__(self) -> str:
         return f"{self._model} {self._id}"

--- a/tests/molstruct/test_structure.py
+++ b/tests/molstruct/test_structure.py
@@ -1,20 +1,47 @@
 
+from multiprocessing.connection import _ForkingPickler
 import pickle
 from pdb2sql import pdb2sql
 
 from deeprankcore.utils.buildgraph import get_structure
+from deeprankcore.molstruct.structure import PDBStructure
 
 
-def test_serialization():
-
-    path = "tests/data/pdb/101M/101M.pdb"
+def _get_structure(path) -> PDBStructure:
     pdb = pdb2sql(path)
     try:
         structure = get_structure(pdb, "101M")
     finally:
         pdb._close()
 
+    assert structure is not None
+
+    return structure
+
+
+def test_serialization_pickle():
+
+    structure = _get_structure("tests/data/pdb/101M/101M.pdb")
+
     s = pickle.dumps(structure)
     loaded_structure = pickle.loads(s)
 
     assert loaded_structure == structure
+    assert loaded_structure.get_chain("A") == structure.get_chain("A")
+    assert loaded_structure.get_chain("A").get_residue(0) == structure.get_chain("A").get_residue(0)
+    assert loaded_structure.get_chain("A").get_residue(0).amino_acid == structure.get_chain("A").get_residue(0).amino_acid
+    assert loaded_structure.get_chain("A").get_residue(0).atoms[0] == structure.get_chain("A").get_residue(0).atoms[0]
+
+
+def test_serialization_fork():
+
+    structure = _get_structure("tests/data/pdb/101M/101M.pdb")
+
+    s = _ForkingPickler.dumps(structure)
+    loaded_structure = _ForkingPickler.loads(s)
+
+    assert loaded_structure == structure
+    assert loaded_structure.get_chain("A") == structure.get_chain("A")
+    assert loaded_structure.get_chain("A").get_residue(0) == structure.get_chain("A").get_residue(0)
+    assert loaded_structure.get_chain("A").get_residue(0).amino_acid == structure.get_chain("A").get_residue(0).amino_acid
+    assert loaded_structure.get_chain("A").get_residue(0).atoms[0] == structure.get_chain("A").get_residue(0).atoms[0]

--- a/tests/molstruct/test_structure.py
+++ b/tests/molstruct/test_structure.py
@@ -1,0 +1,20 @@
+
+import pickle
+from pdb2sql import pdb2sql
+
+from deeprankcore.utils.buildgraph import get_structure
+
+
+def test_serialization():
+
+    path = "tests/data/pdb/101M/101M.pdb"
+    pdb = pdb2sql(path)
+    try:
+        structure = get_structure(pdb, "101M")
+    finally:
+        pdb._close()
+
+    s = pickle.dumps(structure)
+    loaded_structure = pickle.loads(s)
+
+    assert loaded_structure == structure


### PR DESCRIPTION
Hard to reproduce:

```
  File "/home/cbaakman/anaconda3/lib/python3.9/threading.py", line 980, in _bootstrap_inner
    self.run()
  File "/home/cbaakman/anaconda3/lib/python3.9/threading.py", line 917, in run 
    self._target(*self._args, **self._kwargs)
  File "/home/cbaakman/anaconda3/lib/python3.9/multiprocessing/pool.py", line 576, in _handle_results
    task = get()
  File "/home/cbaakman/anaconda3/lib/python3.9/multiprocessing/connection.py", line 256, in recv
    return _ForkingPickler.loads(buf.getbuffer())
  File "/home/cbaakman/projects/deeprank-core/deeprankcore/molstruct/residue.py", line 41, in __hash__
    return hash((self._chain, self._number, self._insertion_code))
  File "/home/cbaakman/projects/deeprank-core/deeprankcore/molstruct/structure.py", line 115, in __hash__
    return hash((self._model, self._id))
AttributeError: 'Chain' object has no attribute '_model'
```