### PR TITLE
fix: match the assumed aa order of the code to the pssm files

### DIFF
--- a/deeprankcore/features/conservation.py
+++ b/deeprankcore/features/conservation.py
@@ -7,13 +7,13 @@ from deeprankcore.molstruct.atom import Atom
 from deeprankcore.utils.graph import Graph
 from deeprankcore.domain import nodestorage as Nfeat
 
-profile_amino_acid_order = sorted(amino_acids, key=lambda aa: aa.one_letter_code)
-
 
 def add_features( # pylint: disable=unused-argument
     pdb_path: str, graph: Graph,
     single_amino_acid_variant: Optional[SingleResidueVariant] = None
     ):
+
+    profile_amino_acid_order = sorted(amino_acids, key=lambda aa: aa.three_letter_code)
 
     for node in graph.nodes:
         if isinstance(node.id, Residue):

--- a/deeprankcore/utils/parsing/pssm.py
+++ b/deeprankcore/utils/parsing/pssm.py
@@ -4,10 +4,6 @@ from deeprankcore.molstruct.residue import Residue
 from deeprankcore.utils.pssmdata import PssmRow, PssmTable
 from deeprankcore.domain.aminoacidlist import amino_acids
 
-amino_acids_by_letter = {
-    amino_acid.one_letter_code: amino_acid for amino_acid in amino_acids
-}
-
 
 def parse_pssm(file_: TextIO, chain: Chain) -> PssmTable:
     """Read the PSSM data.
@@ -20,6 +16,7 @@ def parse_pssm(file_: TextIO, chain: Chain) -> PssmTable:
         PssmTable: The position-specific scoring table, parsed from the pssm file.
     """
 
+    amino_acids_by_letter = {amino_acid.one_letter_code: amino_acid for amino_acid in amino_acids}
     conservation_rows = {}
 
     # Read the pssm header.

--- a/deeprankcore/utils/pssmdata.py
+++ b/deeprankcore/utils/pssmdata.py
@@ -1,10 +1,6 @@
 from typing import Optional, Dict, List
 from deeprankcore.molstruct.aminoacid import AminoAcid
-from deeprankcore.domain.aminoacidlist import amino_acids
 
-amino_acids_by_letter = {
-    amino_acid.one_letter_code: amino_acid for amino_acid in amino_acids
-}
 
 class PssmRow:
     """Holds data for one position-specific scoring matrix row."""

--- a/tests/data/pssm/1ATN/1ATN.A.pdb.deeprank.pssm
+++ b/tests/data/pssm/1ATN/1ATN.A.pdb.deeprank.pssm
@@ -1,1 +1,0 @@
-pdbresi pdbresn seqresi seqresn    A    R    N    D    C    Q    E        G    H    I    L    K    M    F    P    S    T    W    Y    V   IC


### PR DESCRIPTION
There should be some form of documentation on what the pssm files should look like, as it is very easy get it wrong and very difficult to diagnose or even detect if it is.

Even nicer would be to read the order from the top of the pssm file instead of assuming a fixed order.

Also, ideally if pssm files are not present, the code shouldn't crash but just skip that feature and throw a warning (is nicer for users that don't have pssm files not to have to dive into code to actively remove the feature).