### PR TITLE
fix: covalent bonds cannot link nodes on separate branches

### DIFF
--- a/deeprankcore/domain/edgestorage.py
+++ b/deeprankcore/domain/edgestorage.py
@@ -12,5 +12,5 @@ SAMERES = "same_res" # bool
 
 ## interactions
 COVALENT = "covalent" # bool; former FEATURENAME_COVALENT
-ELEC = "e_elec" # float; former FEATURENAME_EDGECOULOMB
-VDW = "e_vdw" # float; former FEATURENAME_EDGEVANDERWAALS
+ELEC = "electrostatic" # float; former FEATURENAME_EDGECOULOMB
+VDW = "vanderwaals" # float; former FEATURENAME_EDGEVANDERWAALS

--- a/deeprankcore/domain/edgestorage.py
+++ b/deeprankcore/domain/edgestorage.py
@@ -12,5 +12,5 @@ SAMERES = "same_res" # bool
 
 ## interactions
 COVALENT = "covalent" # bool; former FEATURENAME_COVALENT
-ELECTROSTATIC = "electrostatic" # float; former FEATURENAME_EDGECOULOMB
-VANDERWAALS = "vanderwaals" # float; former FEATURENAME_EDGEVANDERWAALS
+ELEC = "e_elec" # float; former FEATURENAME_EDGECOULOMB
+VDW = "e_vdw" # float; former FEATURENAME_EDGEVANDERWAALS

--- a/deeprankcore/features/contact.py
+++ b/deeprankcore/features/contact.py
@@ -100,7 +100,6 @@ def add_features( # pylint: disable=unused-argument, too-many-locals
         interatomic_distances = distance_matrix(positions, positions)
         interatomic_electrostatic_energy, interatomic_vanderwaals_energy = _get_nonbonded_energy(all_atoms, interatomic_distances)
 
-
     # assign features
     for edge in graph.edges:
         contact = edge.id
@@ -116,7 +115,6 @@ def add_features( # pylint: disable=unused-argument, too-many-locals
             edge.features[Efeat.ELECTROSTATIC] = interatomic_electrostatic_energy[atom1_index, atom2_index]
             edge.features[Efeat.VANDERWAALS] = interatomic_vanderwaals_energy[atom1_index, atom2_index]
 
-    
         elif isinstance(contact, ResidueContact):
             ## find the indices
             atom1_indices = [atom_dict[atom] for atom in contact.residue1.atoms]
@@ -129,4 +127,3 @@ def add_features( # pylint: disable=unused-argument, too-many-locals
         
         # Calculate irrespective of node type
         edge.features[Efeat.COVALENT] = float(edge.features[Efeat.DISTANCE] < covalent_cutoff and edge.features[Efeat.SAMECHAIN])
-

--- a/deeprankcore/features/contact.py
+++ b/deeprankcore/features/contact.py
@@ -118,8 +118,8 @@ def add_features( # pylint: disable=unused-argument, too-many-locals
             edge.features[Efeat.SAMERES] = float(contact.atom1.residue == contact.atom2.residue)
             edge.features[Efeat.SAMECHAIN] = float(contact.atom1.residue.chain == contact.atom1.residue.chain)
             edge.features[Efeat.DISTANCE] = interatomic_distances[atom1_index, atom2_index]
-            edge.features[Efeat.ELECTROSTATIC] = interatomic_electrostatic_energy[atom1_index, atom2_index]
-            edge.features[Efeat.VANDERWAALS] = interatomic_vanderwaals_energy[atom1_index, atom2_index]
+            edge.features[Efeat.ELEC] = interatomic_electrostatic_energy[atom1_index, atom2_index]
+            edge.features[Efeat.VDW] = interatomic_vanderwaals_energy[atom1_index, atom2_index]
 
         elif isinstance(contact, ResidueContact):
             ## find the indices
@@ -128,8 +128,8 @@ def add_features( # pylint: disable=unused-argument, too-many-locals
             ## set features
             edge.features[Efeat.SAMECHAIN] = float(contact.residue1.chain == contact.residue2.chain)
             edge.features[Efeat.DISTANCE] = np.min([[interatomic_distances[a1, a2] for a1 in atom1_indices] for a2 in atom2_indices])
-            edge.features[Efeat.ELECTROSTATIC] = np.sum([[interatomic_electrostatic_energy[a1, a2] for a1 in atom1_indices] for a2 in atom2_indices])
-            edge.features[Efeat.VANDERWAALS] = np.sum([[interatomic_vanderwaals_energy[a1, a2] for a1 in atom1_indices] for a2 in atom2_indices])
+            edge.features[Efeat.ELEC] = np.sum([[interatomic_electrostatic_energy[a1, a2] for a1 in atom1_indices] for a2 in atom2_indices])
+            edge.features[Efeat.VDW] = np.sum([[interatomic_vanderwaals_energy[a1, a2] for a1 in atom1_indices] for a2 in atom2_indices])
         
         # Calculate irrespective of node type
         edge.features[Efeat.COVALENT] = float(edge.features[Efeat.DISTANCE] < covalent_cutoff and edge.features[Efeat.SAMECHAIN])

--- a/tests/data/hdf5/_generate_testdata.ipynb
+++ b/tests/data/hdf5/_generate_testdata.ipynb
@@ -43,6 +43,8 @@
    "source": [
     "import warnings\n",
     "from Bio import BiopythonWarning\n",
+    "from deeprankcore.utils.grid import GridSettings, MapMethod\n",
+    "\n",
     "with warnings.catch_warnings():\n",
     "    warnings.simplefilter(\"ignore\", BiopythonWarning)\n",
     "    warnings.simplefilter(\"ignore\", RuntimeWarning)\n",
@@ -75,7 +77,11 @@
     "        ))\n",
     "\n",
     "    # Generate graphs and save them in hdf5 files\n",
-    "    output_paths = queries.process(cpu_count=1, prefix='1ATN_ppi')"
+    "    output_paths = queries.process(cpu_count=1,\n",
+    "                                   prefix='1ATN_ppi',\n",
+    "                                   grid_settings=GridSettings([20, 20, 20], [20.0, 20.0, 20.0]),\n",
+    "                                   grid_map_method=MapMethod.GAUSSIAN,\n",
+    "                                   )"
    ]
   },
   {

--- a/tests/features/test_contact.py
+++ b/tests/features/test_contact.py
@@ -68,8 +68,8 @@ def _get_contact( # pylint: disable=too-many-arguments
     edge_obj = Edge(contact)
     add_features(pdb_path, _wrap_in_graph(edge_obj))
     
-    assert not np.isnan(edge_obj.features[Efeat.VANDERWAALS]), 'isnan vdw'
-    assert not np.isnan(edge_obj.features[Efeat.ELECTROSTATIC]), 'isnan electrostatic'
+    assert not np.isnan(edge_obj.features[Efeat.VDW]), 'isnan vdw'
+    assert not np.isnan(edge_obj.features[Efeat.ELEC]), 'isnan electrostatic'
     assert not np.isnan(edge_obj.features[Efeat.DISTANCE]), 'isnan distance'
     assert not np.isnan(edge_obj.features[Efeat.SAMECHAIN]), 'isnan samechain'
     assert not np.isnan(edge_obj.features[Efeat.COVALENT]), 'isnan covalent'
@@ -85,8 +85,8 @@ def test_covalent_pair():
 
     edge_covalent = _get_contact('101M', 0, "N", 0, "CA")
     assert edge_covalent.features[Efeat.DISTANCE] < covalent_cutoff
-    assert edge_covalent.features[Efeat.VANDERWAALS] == 0.0, 'nonzero vdw energy for covalent pair'
-    assert edge_covalent.features[Efeat.ELECTROSTATIC] == 0.0, 'nonzero electrostatic energy for covalent pair'
+    assert edge_covalent.features[Efeat.VDW] == 0.0, 'nonzero vdw energy for covalent pair'
+    assert edge_covalent.features[Efeat.ELEC] == 0.0, 'nonzero electrostatic energy for covalent pair'
     assert edge_covalent.features[Efeat.COVALENT] == 1.0, 'covalent pair not recognized as covalent'
 
 
@@ -96,8 +96,8 @@ def test_13_pair():
 
     edge_13 = _get_contact('101M', 0, "N", 0, "CB")
     assert edge_13.features[Efeat.DISTANCE] < cutoff_13
-    assert edge_13.features[Efeat.VANDERWAALS] == 0.0, 'nonzero vdw energy for 1-3 pair'
-    assert edge_13.features[Efeat.ELECTROSTATIC] == 0.0, 'nonzero electrostatic energy for 1-3 pair'
+    assert edge_13.features[Efeat.VDW] == 0.0, 'nonzero vdw energy for 1-3 pair'
+    assert edge_13.features[Efeat.ELEC] == 0.0, 'nonzero electrostatic energy for 1-3 pair'
     assert edge_13.features[Efeat.COVALENT] == 0.0, '1-3 pair recognized as covalent'
     
 
@@ -107,8 +107,8 @@ def test_very_close_opposing_chains():
 
     opposing_edge = _get_contact('1A0Z', 118, "O", 30, "NH1", chains=('A', 'B'))
     assert opposing_edge.features[Efeat.DISTANCE] < cutoff_13
-    assert opposing_edge.features[Efeat.ELECTROSTATIC] != 0.0
-    assert opposing_edge.features[Efeat.VANDERWAALS] != 0.0
+    assert opposing_edge.features[Efeat.ELEC] != 0.0
+    assert opposing_edge.features[Efeat.VDW] != 0.0
 
 
 def test_14_pair():
@@ -118,9 +118,9 @@ def test_14_pair():
     edge_14 = _get_contact('101M', 0, "CA", 0, "SD")
     assert edge_14.features[Efeat.DISTANCE] > cutoff_13
     assert edge_14.features[Efeat.DISTANCE] < cutoff_14
-    assert edge_14.features[Efeat.VANDERWAALS] != 0.0, '1-4 pair with 0 vdw energy'
-    assert abs(edge_14.features[Efeat.VANDERWAALS]) < 0.1, '1-4 pair with large vdw energy'
-    assert edge_14.features[Efeat.ELECTROSTATIC] != 0.0, '1-4 pair with 0 electrostatic'
+    assert edge_14.features[Efeat.VDW] != 0.0, '1-4 pair with 0 vdw energy'
+    assert abs(edge_14.features[Efeat.VDW]) < 0.1, '1-4 pair with large vdw energy'
+    assert edge_14.features[Efeat.ELEC] != 0.0, '1-4 pair with 0 electrostatic'
     assert edge_14.features[Efeat.COVALENT] == 0.0, '1-4 pair recognized as covalent'
 
 
@@ -133,8 +133,8 @@ def test_14dist_opposing_chains():
     opposing_edge = _get_contact('1A0Z', 114, "CA", 116, "CD2", chains=('A', 'B'))
     assert opposing_edge.features[Efeat.DISTANCE] > cutoff_13
     assert opposing_edge.features[Efeat.DISTANCE] < cutoff_14
-    assert opposing_edge.features[Efeat.ELECTROSTATIC] > 1.0, f'electrostatic: {opposing_edge.features[Efeat.ELECTROSTATIC]}'
-    assert opposing_edge.features[Efeat.VANDERWAALS] > 0.1, f'vdw: {opposing_edge.features[Efeat.VANDERWAALS]}'
+    assert opposing_edge.features[Efeat.ELEC] > 1.0, f'electrostatic: {opposing_edge.features[Efeat.ELEC]}'
+    assert opposing_edge.features[Efeat.VDW] > 0.1, f'vdw: {opposing_edge.features[Efeat.VDW]}'
 
 
 def test_vanderwaals_negative():
@@ -142,7 +142,7 @@ def test_vanderwaals_negative():
     """
 
     edge_far = _get_contact('101M', 0, "N", 27, "CB")
-    assert edge_far.features[Efeat.VANDERWAALS] < 0.0
+    assert edge_far.features[Efeat.VDW] < 0.0
 
     
 def test_vanderwaals_morenegative():
@@ -151,7 +151,7 @@ def test_vanderwaals_morenegative():
 
     edge_intermediate = _get_contact('101M', 0, "N", 138, "CG")
     edge_far = _get_contact('101M', 0, "N", 27, "CB")
-    assert edge_intermediate.features[Efeat.VANDERWAALS] < edge_far.features[Efeat.VANDERWAALS]
+    assert edge_intermediate.features[Efeat.VDW] < edge_far.features[Efeat.VDW]
 
 
 def test_edge_distance():
@@ -177,7 +177,7 @@ def test_attractive_electrostatic_close():
     """
 
     close_attracting_edge = _get_contact('101M', 139, "CZ", 136, "OE2")
-    assert close_attracting_edge.features[Efeat.ELECTROSTATIC] < 0.0
+    assert close_attracting_edge.features[Efeat.ELEC] < 0.0
 
 
 def test_attractive_electrostatic_far():
@@ -187,11 +187,11 @@ def test_attractive_electrostatic_far():
     far_attracting_edge = _get_contact('101M', 139, "CZ", 20, "OD2")
     close_attracting_edge = _get_contact('101M', 139, "CZ", 136, "OE2")
     assert (
-        far_attracting_edge.features[Efeat.ELECTROSTATIC] < 0.0
+        far_attracting_edge.features[Efeat.ELEC] < 0.0
     ), 'far electrostatic > 0'
     assert (
-        far_attracting_edge.features[Efeat.ELECTROSTATIC]
-        > close_attracting_edge.features[Efeat.ELECTROSTATIC]
+        far_attracting_edge.features[Efeat.ELEC]
+        > close_attracting_edge.features[Efeat.ELEC]
     ), 'far electrostatic <= close electrostatic'
    
 
@@ -200,7 +200,7 @@ def test_repulsive_electrostatic():
     """
 
     opposing_edge = _get_contact('101M', 109, "OE2", 105, "OE1")
-    assert opposing_edge.features[Efeat.ELECTROSTATIC] > 0.0
+    assert opposing_edge.features[Efeat.ELEC] > 0.0
 
 
 def test_residue_contact():
@@ -210,6 +210,6 @@ def test_residue_contact():
     res_edge = _get_contact('101M', 0, '', 1, '', residue_level = True)
     assert res_edge.features[Efeat.DISTANCE] > 0.0, 'distance <= 0'
     assert res_edge.features[Efeat.DISTANCE] < 1e5, 'distance > 1e5'
-    assert res_edge.features[Efeat.ELECTROSTATIC] != 0.0, 'electrostatic == 0'
-    assert res_edge.features[Efeat.VANDERWAALS] != 0.0, 'vanderwaals == 0'
+    assert res_edge.features[Efeat.ELEC] != 0.0, 'electrostatic == 0'
+    assert res_edge.features[Efeat.VDW] != 0.0, 'vanderwaals == 0'
     assert res_edge.features[Efeat.COVALENT] == 1.0, 'neighboring residues not seen as covalent'

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -37,7 +37,7 @@ class TestDataSet(unittest.TestCase):
                                                                     edge_features=[Efeat.DISTANCE],
                                                                     target=targets.IRMSD)),
                                       ("GridDataset", GridDataset(self.hdf5_path,
-                                                                  features=[Efeat.VANDERWAALS],
+                                                                  features=[Efeat.VDW],
                                                                   target=targets.IRMSD))]:
 
             entry_names = []
@@ -66,7 +66,7 @@ class TestDataSet(unittest.TestCase):
     def test_grid_dataset_regression(self):
         dataset = GridDataset(
             hdf5_path=self.hdf5_path,
-            features=[Efeat.VANDERWAALS, Efeat.ELECTROSTATIC],
+            features=[Efeat.VDW, Efeat.ELEC],
             target=targets.IRMSD
         )
 
@@ -81,7 +81,7 @@ class TestDataSet(unittest.TestCase):
     def test_grid_dataset_classification(self):
         dataset = GridDataset(
             hdf5_path=self.hdf5_path,
-            features=[Efeat.VANDERWAALS, Efeat.ELECTROSTATIC],
+            features=[Efeat.VDW, Efeat.ELEC],
             target=targets.BINARY
         )
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -169,8 +169,8 @@ def test_variant_graph_101M():
         ],
         [
             Efeat.DISTANCE,
-            Efeat.VANDERWAALS,
-            Efeat.ELECTROSTATIC,
+            Efeat.VDW,
+            Efeat.ELEC,
         ],
     )
 
@@ -209,8 +209,8 @@ def test_variant_graph_1A0Z():
         ],
         [
             Efeat.DISTANCE,
-            Efeat.VANDERWAALS,
-            Efeat.ELECTROSTATIC,
+            Efeat.VDW,
+            Efeat.ELEC,
         ],
     )
 
@@ -247,8 +247,8 @@ def test_variant_graph_9API():
         ],
         [
             Efeat.DISTANCE,
-            Efeat.VANDERWAALS,
-            Efeat.ELECTROSTATIC,
+            Efeat.VDW,
+            Efeat.ELEC,
         ],
     )
 
@@ -288,7 +288,7 @@ def test_res_ppi():
 
     g = query.build([surfacearea, contact])
 
-    _check_graph_makes_sense(g, [Nfeat.SASA], [Efeat.ELECTROSTATIC])
+    _check_graph_makes_sense(g, [Nfeat.SASA], [Efeat.ELEC])
 
 
 def test_augmentation():

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -130,7 +130,7 @@ class TestTrainer(unittest.TestCase):
             subset=None,
             target=targets.IRMSD,
             task=targets.REGRESS,
-            features=[Efeat.VANDERWAALS]
+            features=[Efeat.VDW]
         )
         trainer = Trainer(
             CnnRegression,
@@ -144,7 +144,7 @@ class TestTrainer(unittest.TestCase):
             subset=None,
             target=targets.BINARY,
             task=targets.CLASSIF,
-            features=[Efeat.VANDERWAALS])
+            features=[Efeat.VDW])
         trainer = Trainer(
             CnnClassification,
             dataset
@@ -157,7 +157,7 @@ class TestTrainer(unittest.TestCase):
             subset=None,
             target=targets.BINARY,
             task=targets.CLASSIF,
-            features=[Efeat.VANDERWAALS]
+            features=[Efeat.VDW]
         )
         dataset_valid = GraphDataset(
             hdf5_path="tests/data/hdf5/valid.hdf5",


### PR DESCRIPTION
Prior to this PR, nodes on separate chains could be considered to be covalent pairs (for "covalent" feature) and 1-3 or 1-4 pairs (for energy features), as these were all based solely on cutoff distances.
Now, the code also checks whether nodes are on the same chain or not, and only considers them bonded if they are on the same chain.
 
closes #407 