### PR TITLE
fix: only check pssms if conservation module was used

### DIFF
--- a/deeprankcore/query.py
+++ b/deeprankcore/query.py
@@ -34,7 +34,7 @@ from deeprankcore.utils.parsing.pssm import parse_pssm
 _log = logging.getLogger(__name__)
 
 
-def _check_pssm(pdb_path: str, pssm_paths: Dict[str, str], verbose = False):
+def _check_pssm(pdb_path: str, pssm_paths: Dict[str, str]):
     """Checks whether information stored in PSSM file matches the PDB file.
 
     Args:
@@ -59,24 +59,13 @@ def _check_pssm(pdb_path: str, pssm_paths: Dict[str, str], verbose = False):
     pdb_truth = pdb2sql.pdb2sql(pdb_path).get_residues()
     pdb_truth = {res[0] + str(res[2]).zfill(4): res[1] for res in pdb_truth}
 
-    n_wrong = 0
-    n_missing = 0
+    error_message = f'Amino acids in PSSM files do not match pdb file for {os.path.split(pdb_path)[1]}.'
     for residue in pdb_truth:
         try: 
             if pdb_truth[residue] != pssm_data[residue]:
-                n_wrong += 1
+                raise ValueError(error_message)
         except KeyError:
-            n_missing += 1
-
-    if n_missing + n_wrong > 0:
-        _, filename = os.path.split(pdb_path)
-        error_message = f'Amino acids in PSSM files do not match pdb file for {filename}.'
-        if verbose:
-            if n_wrong > 0:
-                error_message = error_message + f'\n\t{n_wrong} entries are incorrect.'
-            if n_missing > 0:
-                error_message = error_message + f'\n\t{n_missing} entries are missing.'
-        raise ValueError(error_message)
+            raise ValueError(error_message) #pylint: disable = raise-missing-from
 
 
 class Query:

--- a/deeprankcore/query.py
+++ b/deeprankcore/query.py
@@ -42,8 +42,11 @@ def _check_pssm(pdb_path: str, pssm_paths: Dict[str, str], verbose = False):
         pssm_paths (Dict[str, str]): The paths to the PSSM files, per chain identifier.
 
     Raises:
-        ValueError: Raised if info between PDB and PSSM doesn't match
+        ValueError: Raised if info between PDB and PSSM doesn't match or if no pssms were provided
     """
+
+    if not pssm_paths:
+        raise ValueError('No pssm paths provided for conservation feature module.')
 
     pssm_data = {}
     for chain in pssm_paths:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -377,7 +377,7 @@ def test_incorrect_pssm_order():
                 "A": "tests/data/pssm/3C8P_incorrect/3C8P.A.wrong_order.pdb.pssm",
                 "B": "tests/data/pssm/3C8P/3C8P.B.pdb.pssm",
             },
-        ).build(components)
+        ).build(conservation)
 
 
 def test_incomplete_pssm():
@@ -390,4 +390,4 @@ def test_incomplete_pssm():
                 "A": "tests/data/pssm/3C8P/3C8P.A.pdb.pssm",
                 "B": "tests/data/pssm/3C8P_incorrect/3C8P.B.missing_res.pdb.pssm",
             },
-        ).build(components)
+        ).build(conservation)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -391,3 +391,42 @@ def test_incomplete_pssm():
                 "B": "tests/data/pssm/3C8P_incorrect/3C8P.B.missing_res.pdb.pssm",
             },
         ).build(conservation)
+
+
+def test_no_pssm_provided():
+    with pytest.raises(ValueError):
+        _ = ProteinProteinInterfaceResidueQuery(
+            "tests/data/pdb/3C8P/3C8P.pdb",
+            "A",
+            "B",
+            {},
+        ).build(conservation)
+        
+        _ = ProteinProteinInterfaceResidueQuery(
+            "tests/data/pdb/3C8P/3C8P.pdb",
+            "A",
+            "B",
+        ).build(conservation)
+
+
+def test_incorrect_pssm_provided():
+    with pytest.raises(FileNotFoundError):
+        _ = ProteinProteinInterfaceResidueQuery(
+            "tests/data/pdb/3C8P/3C8P.pdb",
+            "A",
+            "B",
+            {
+                "A": "dummy_non_existing_file",
+                "B": "tests/data/pssm/3C8P_incorrect/3C8P.B.missing_res.pdb.pssm",
+            },
+        ).build(conservation)
+
+    with pytest.raises(ValueError):
+        _ = ProteinProteinInterfaceResidueQuery(
+            "tests/data/pdb/3C8P/3C8P.pdb",
+            "A",
+            "B",
+            {
+                "B": "tests/data/pssm/3C8P_incorrect/3C8P.B.missing_res.pdb.pssm",
+            },
+        ).build(conservation)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -378,6 +378,17 @@ def test_incorrect_pssm_order():
                 "B": "tests/data/pssm/3C8P/3C8P.B.pdb.pssm",
             },
         ).build(conservation)
+    
+    # should not raise error conservation module is not used
+    _ = ProteinProteinInterfaceResidueQuery(
+        "tests/data/pdb/3C8P/3C8P.pdb",
+        "A",
+        "B",
+        {
+            "A": "tests/data/pssm/3C8P_incorrect/3C8P.A.wrong_order.pdb.pssm",
+            "B": "tests/data/pssm/3C8P/3C8P.B.pdb.pssm",
+        },
+    ).build(components)
 
 
 def test_incomplete_pssm():
@@ -392,9 +403,21 @@ def test_incomplete_pssm():
             },
         ).build(conservation)
 
+    # no error if conservation module is not used
+    _ = ProteinProteinInterfaceResidueQuery(
+        "tests/data/pdb/3C8P/3C8P.pdb",
+        "A",
+        "B",
+        {
+            "A": "tests/data/pssm/3C8P_incorrect/3C8P.A.wrong_order.pdb.pssm",
+            "B": "tests/data/pssm/3C8P/3C8P.B.pdb.pssm",
+        },
+    ).build(components)
+
 
 def test_no_pssm_provided():
     with pytest.raises(ValueError):
+        # pssm_paths is empty dictionary
         _ = ProteinProteinInterfaceResidueQuery(
             "tests/data/pdb/3C8P/3C8P.pdb",
             "A",
@@ -402,25 +425,44 @@ def test_no_pssm_provided():
             {},
         ).build(conservation)
         
+        # pssm_paths not provided 
         _ = ProteinProteinInterfaceResidueQuery(
             "tests/data/pdb/3C8P/3C8P.pdb",
             "A",
             "B",
         ).build(conservation)
 
+    # no error if conservation module is not used
+    # pssm_paths is empty dictionary
+    _ = ProteinProteinInterfaceResidueQuery(
+        "tests/data/pdb/3C8P/3C8P.pdb",
+        "A",
+        "B",
+        {},
+    ).build(components)
+    
+    # pssm_paths not provided 
+    _ = ProteinProteinInterfaceResidueQuery(
+        "tests/data/pdb/3C8P/3C8P.pdb",
+        "A",
+        "B",
+    ).build(components)
+
 
 def test_incorrect_pssm_provided():
+    # non-existing file
     with pytest.raises(FileNotFoundError):
         _ = ProteinProteinInterfaceResidueQuery(
             "tests/data/pdb/3C8P/3C8P.pdb",
             "A",
             "B",
             {
-                "A": "dummy_non_existing_file",
+                "A": "tests/data/pssm/3C8P_incorrect/dummy_non_existing_file.pssm",
                 "B": "tests/data/pssm/3C8P_incorrect/3C8P.B.missing_res.pdb.pssm",
             },
         ).build(conservation)
 
+    # missing file
     with pytest.raises(ValueError):
         _ = ProteinProteinInterfaceResidueQuery(
             "tests/data/pdb/3C8P/3C8P.pdb",
@@ -430,3 +472,25 @@ def test_incorrect_pssm_provided():
                 "B": "tests/data/pssm/3C8P_incorrect/3C8P.B.missing_res.pdb.pssm",
             },
         ).build(conservation)
+    
+    # no error if conservation module is not used
+    # non-existing file
+    _ = ProteinProteinInterfaceResidueQuery(
+        "tests/data/pdb/3C8P/3C8P.pdb",
+        "A",
+        "B",
+        {
+            "A": "tests/data/pssm/3C8P_incorrect/dummy_non_existing_file.pssm",
+            "B": "tests/data/pssm/3C8P_incorrect/3C8P.B.missing_res.pdb.pssm",
+        },
+    ).build(components)
+
+    # missing file
+    _ = ProteinProteinInterfaceResidueQuery(
+        "tests/data/pdb/3C8P/3C8P.pdb",
+        "A",
+        "B",
+        {
+            "B": "tests/data/pssm/3C8P_incorrect/3C8P.B.missing_res.pdb.pssm",
+        },
+    ).build(components)


### PR DESCRIPTION
- Only run `_check_pssms` if conservation module is active
  - Test that runs without error if module is not used, even if pssms are bad
  - Make error less verbose
- Add test for error if missing or typoed/incorrect pssm filenames


Error is still raised and hdf5 files not created if pssm files are faulty, as per [this comment](https://github.com/DeepRank/deeprank-core/issues/424#issuecomment-1548080457).

closes #424 
