### PR TITLE
fix: epoch number in `test()` and test on the correct model

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,12 +290,11 @@ trainer.configure_optimizers(torch.optim.Adamax, lr = 0.001, weight_decay = 1e-0
 
 ```
 
-Then the Trainer can be trained and tested, and the model can be saved:
+Then the Trainer can be trained and tested; the best model in terms of validation loss is saved by default, and the user can modify so or indicate where to save it using the `train()` method parameters `save_model` and `output_prefix`.
 
 ```python
 trainer.train(nepoch = 50, batch_size = 64, validate = True)
 trainer.test()
-trainer.save_model(filename = "<output_model_path.pth.tar>")
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ trainer.configure_optimizers(torch.optim.Adamax, lr = 0.001, weight_decay = 1e-0
 
 ```
 
-Then the Trainer can be trained and tested; the best model in terms of validation loss is saved by default, and the user can modify so or indicate where to save it using the `train()` method parameters `save_model` and `output_prefix`.
+Then the Trainer can be trained and tested; the best model in terms of validation loss is saved by default, and the user can modify so or indicate where to save it using the `train()` method parameters `save_model` and `filename`.
 
 ```python
 trainer.train(nepoch = 50, batch_size = 64, validate = True)

--- a/README.md
+++ b/README.md
@@ -290,10 +290,14 @@ trainer.configure_optimizers(torch.optim.Adamax, lr = 0.001, weight_decay = 1e-0
 
 ```
 
-Then the Trainer can be trained and tested; the best model in terms of validation loss is saved by default, and the user can modify so or indicate where to save it using the `train()` method parameters `save_model` and `filename`.
+Then the Trainer can be trained and tested; the best model in terms of validation loss is saved by default, and the user can modify so or indicate where to save it using the `train()` method parameter `filename`.
 
 ```python
-trainer.train(nepoch = 50, batch_size = 64, validate = True)
+trainer.train(
+    nepoch = 50,
+    batch_size = 64,
+    validate = True,
+    filename = "<my_folder/model.pth.tar>")
 trainer.test()
 
 ```

--- a/deeprankcore/trainer.py
+++ b/deeprankcore/trainer.py
@@ -641,7 +641,7 @@ class Trainer():
                     valid_losses.append(loss_)
                     if best_model:
                         if min(valid_losses) == loss_:
-                            checkpoint_model = self.save_model()
+                            checkpoint_model = self._save_model()
                             self.epoch_saved_model = epoch
                             _log.info(f'Best model saved at epoch # {self.epoch_saved_model}.')
                     # check early stopping criteria (in validation case only)
@@ -658,13 +658,13 @@ class Trainer():
                             _log.warning(
                                 "Training data is used both for learning and model selection, which will to overfitting." +
                                 "\n\tIt is preferable to use an independent training and validation data sets.")
-                            checkpoint_model = self.save_model()
+                            checkpoint_model = self._save_model()
                             self.epoch_saved_model = epoch
                             _log.info(f'Best model saved at epoch # {self.epoch_saved_model}.')
 
             # Save the last model
             if best_model is False:
-                checkpoint_model = self.save_model()
+                checkpoint_model = self._save_model()
                 self.epoch_saved_model = epoch
                 _log.info(f'Last model saved at epoch # {self.epoch_saved_model}.')
 
@@ -906,7 +906,7 @@ class Trainer():
         self.cuda = state["cuda"]
         self.ngpu = state["ngpu"]
 
-    def save_model(self, filename: Optional[str] = None):
+    def _save_model(self, filename: Optional[str] = None):
         """
         Saves the model to a file.
 

--- a/deeprankcore/trainer.py
+++ b/deeprankcore/trainer.py
@@ -1,6 +1,5 @@
 import copy
 import logging
-from pathlib import Path
 from time import time
 from typing import List, Optional, Tuple, Union
 

--- a/deeprankcore/trainer.py
+++ b/deeprankcore/trainer.py
@@ -521,7 +521,7 @@ class Trainer():
         num_workers: int = 0,
         best_model: bool = True,
         save_model: bool = True,
-        output_prefix: Optional[str] = None,
+        filename: str = 'model.pth.tar'
     ):
         """
         Performs the training of the model.
@@ -548,11 +548,10 @@ class Trainer():
                         If False, the last model tried is selected.
                         Defaults to True.
             save_model (bool, optional): 
-                        If True, the selected model is saved in a file whose prefix is indicated in <output_prefix>.
+                        If True, the selected model is saved in <filename>.
                         If False, no model is saved.
                         Defaults to True.
-            output_prefix (Optional[str], optional): Name under which the model is saved. A description of the model settings is appended to the prefix.
-                        Defaults to None.
+            filename (str, optional): Name of the file where to save the selected model. Defaults to 'model.pth.tar'.
         """
         self.batch_size_train = batch_size
         self.shuffle = shuffle
@@ -612,10 +611,6 @@ class Trainer():
         else: 
             early_stopping = None
 
-        if output_prefix is None:
-            output_prefix = 'model'
-        output_file = output_prefix + f'_t{self.task}_y{self.target}_b{str(self.batch_size_train)}_e{str(nepoch)}_lr{str(self.lr)}_{str(nepoch)}.pth.tar'
-
         with self._output_exporters:
             # Number of epochs
             self.nepoch = nepoch
@@ -668,9 +663,9 @@ class Trainer():
                 self.epoch_saved_model = epoch
                 _log.info(f'Last model saved at epoch # {self.epoch_saved_model}.')
 
-        # Now that the training loop is over, save the model on a file
+        # Now that the training loop is over, save the model
         if save_model:
-            torch.save(checkpoint_model, output_file)
+            torch.save(checkpoint_model, filename)
         self.opt_loaded_state_dict = checkpoint_model["optimizer_state"]
         self.model_load_state_dict = checkpoint_model["model_state"]
         self.optimizer.load_state_dict(self.opt_loaded_state_dict)

--- a/deeprankcore/trainer.py
+++ b/deeprankcore/trainer.py
@@ -519,8 +519,7 @@ class Trainer():
         validate: bool = False,
         num_workers: int = 0,
         best_model: bool = True,
-        save_model: bool = True,
-        filename: str = 'model.pth.tar'
+        filename: Optional[str] = 'model.pth.tar'
     ):
         """
         Performs the training of the model.
@@ -546,11 +545,8 @@ class Trainer():
                         If True, the best model (in terms of validation loss) is selected for later testing or saving.
                         If False, the last model tried is selected.
                         Defaults to True.
-            save_model (bool, optional): 
-                        If True, the selected model is saved in <filename>.
-                        If False, no model is saved.
-                        Defaults to True.
-            filename (str, optional): Name of the file where to save the selected model. Defaults to 'model.pth.tar'.
+            filename (str, optional): Name of the file where to save the selected model. If not None, the model is saved to `filename`.
+                If None, the model is not saved. Defaults to 'model.pth.tar'.
         """
         self.batch_size_train = batch_size
         self.shuffle = shuffle
@@ -663,7 +659,7 @@ class Trainer():
                 _log.info(f'Last model saved at epoch # {self.epoch_saved_model}.')
 
         # Now that the training loop is over, save the model
-        if save_model:
+        if filename:
             torch.save(checkpoint_model, filename)
         self.opt_loaded_state_dict = checkpoint_model["optimizer_state"]
         self.model_load_state_dict = checkpoint_model["model_state"]
@@ -900,7 +896,7 @@ class Trainer():
         self.cuda = state["cuda"]
         self.ngpu = state["ngpu"]
 
-    def _save_model(self, filename: Optional[str] = None):
+    def _save_model(self):
         """
         Saves the model to a file.
 
@@ -931,9 +927,6 @@ class Trainer():
             "cuda": self.cuda,
             "ngpu": self.ngpu
         }
-
-        if filename:
-            torch.save(state, filename)
         
         return state
 

--- a/docs/getstarted.md
+++ b/docs/getstarted.md
@@ -268,7 +268,7 @@ trainer.configure_optimizers(torch.optim.Adamax, lr = 0.001, weight_decay = 1e-0
 
 ```
 
-Then the Trainer can be trained and tested; the best model in terms of validation loss is saved by default, and the user can modify so or indicate where to save it using the `train()` method parameters `save_model` and `output_prefix`.
+Then the Trainer can be trained and tested; the best model in terms of validation loss is saved by default, and the user can modify so or indicate where to save it using the `train()` method parameters `save_model` and `filename`.
 
 ```python
 trainer.train(nepoch = 50, batch_size = 64, validate = True)

--- a/docs/getstarted.md
+++ b/docs/getstarted.md
@@ -268,10 +268,14 @@ trainer.configure_optimizers(torch.optim.Adamax, lr = 0.001, weight_decay = 1e-0
 
 ```
 
-Then the Trainer can be trained and tested; the best model in terms of validation loss is saved by default, and the user can modify so or indicate where to save it using the `train()` method parameters `save_model` and `filename`.
+Then the Trainer can be trained and tested; the best model in terms of validation loss is saved by default, and the user can modify so or indicate where to save it using the `train()` method parameter `filename`.
 
 ```python
-trainer.train(nepoch = 50, batch_size = 64, validate = True)
+trainer.train(
+    nepoch = 50,
+    batch_size = 64,
+    validate = True,
+    filename = "<my_folder/model.pth.tar>")
 trainer.test()
 
 ```

--- a/docs/getstarted.md
+++ b/docs/getstarted.md
@@ -268,12 +268,11 @@ trainer.configure_optimizers(torch.optim.Adamax, lr = 0.001, weight_decay = 1e-0
 
 ```
 
-Then the Trainer can be trained and tested, and the model can be saved:
+Then the Trainer can be trained and tested; the best model in terms of validation loss is saved by default, and the user can modify so or indicate where to save it using the `train()` method parameters `save_model` and `output_prefix`.
 
 ```python
 trainer.train(nepoch = 50, batch_size = 64, validate = True)
 trainer.test()
-trainer.save_model(filename = "<output_model_path.pth.tar>")
 
 ```
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -102,7 +102,7 @@ def test_cnn(): # pylint: disable=too-many-locals
         )
 
         with warnings.catch_warnings(record=UserWarning):
-            trainer.train(nepoch=3, batch_size=64, validate=True, save_best_model=None)
+            trainer.train(nepoch=3, batch_size=64, validate=True, best_model=False, save_model=False)
             trainer.save_model(model_path)
 
             Trainer(CnnClassification, dataset_train, dataset_val, dataset_test, pretrained_model=model_path)
@@ -190,7 +190,7 @@ def test_gnn(): # pylint: disable=too-many-locals
         )
 
         with warnings.catch_warnings(record=UserWarning):
-            trainer.train(nepoch=3, batch_size=64, validate=True, save_best_model=None) 
+            trainer.train(nepoch=3, batch_size=64, validate=True, best_model=False, save_model=False) 
             trainer.save_model(model_path)
 
             Trainer(GINet, dataset_train, dataset_val, dataset_test, pretrained_model=model_path)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -102,7 +102,7 @@ def test_cnn(): # pylint: disable=too-many-locals
         )
 
         with warnings.catch_warnings(record=UserWarning):
-            trainer.train(nepoch=3, batch_size=64, validate=True, best_model=False)
+            trainer.train(nepoch=3, batch_size=64, validate=True, best_model=False, filename=model_path)
 
             Trainer(CnnClassification, dataset_train, dataset_val, dataset_test, pretrained_model=model_path)
 
@@ -189,7 +189,7 @@ def test_gnn(): # pylint: disable=too-many-locals
         )
 
         with warnings.catch_warnings(record=UserWarning):
-            trainer.train(nepoch=3, batch_size=64, validate=True, best_model=False) 
+            trainer.train(nepoch=3, batch_size=64, validate=True, best_model=False, filename=model_path) 
 
             Trainer(GINet, dataset_train, dataset_val, dataset_test, pretrained_model=model_path)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -102,8 +102,7 @@ def test_cnn(): # pylint: disable=too-many-locals
         )
 
         with warnings.catch_warnings(record=UserWarning):
-            trainer.train(nepoch=3, batch_size=64, validate=True, best_model=False, save_model=False)
-            trainer.save_model(model_path)
+            trainer.train(nepoch=3, batch_size=64, validate=True, best_model=False)
 
             Trainer(CnnClassification, dataset_train, dataset_val, dataset_test, pretrained_model=model_path)
 
@@ -190,8 +189,7 @@ def test_gnn(): # pylint: disable=too-many-locals
         )
 
         with warnings.catch_warnings(record=UserWarning):
-            trainer.train(nepoch=3, batch_size=64, validate=True, best_model=False, save_model=False) 
-            trainer.save_model(model_path)
+            trainer.train(nepoch=3, batch_size=64, validate=True, best_model=False) 
 
             Trainer(GINet, dataset_train, dataset_val, dataset_test, pretrained_model=model_path)
 

--- a/tests/test_set_lossfunction.py
+++ b/tests/test_set_lossfunction.py
@@ -21,8 +21,7 @@ def base_test(model_path, trainer: Trainer, lossfunction = None, override = Fals
 
     # check correct passing to/picking up from pretrained model 
     with warnings.catch_warnings(record=UserWarning):
-        trainer.train(nepoch=2, best_model=False, save_model=False)
-        trainer.save_model(model_path)
+        trainer.train(nepoch=2, best_model=False)
 
         trainer_pretrained = Trainer(
             neuralnet = NaiveNetwork,

--- a/tests/test_set_lossfunction.py
+++ b/tests/test_set_lossfunction.py
@@ -21,7 +21,7 @@ def base_test(model_path, trainer: Trainer, lossfunction = None, override = Fals
 
     # check correct passing to/picking up from pretrained model 
     with warnings.catch_warnings(record=UserWarning):
-        trainer.train(nepoch=2, best_model=False)
+        trainer.train(nepoch=2, best_model=False, filename=model_path)
 
         trainer_pretrained = Trainer(
             neuralnet = NaiveNetwork,

--- a/tests/test_set_lossfunction.py
+++ b/tests/test_set_lossfunction.py
@@ -21,7 +21,7 @@ def base_test(model_path, trainer: Trainer, lossfunction = None, override = Fals
 
     # check correct passing to/picking up from pretrained model 
     with warnings.catch_warnings(record=UserWarning):
-        trainer.train(nepoch=2, save_best_model=None)
+        trainer.train(nepoch=2, best_model=False, save_model=False)
         trainer.save_model(model_path)
 
         trainer_pretrained = Trainer(

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -135,7 +135,7 @@ class TestTrainer(unittest.TestCase):
             CnnRegression,
             dataset
         )
-        trainer.train(nepoch=1, batch_size=2, best_model=False, save_model=False)
+        trainer.train(nepoch=1, batch_size=2, best_model=False, filename=None)
 
     def test_grid_classification(self):
         dataset = GridDataset(
@@ -148,7 +148,7 @@ class TestTrainer(unittest.TestCase):
             CnnClassification,
             dataset
         )
-        trainer.train(nepoch=1, batch_size = 2, best_model=False, save_model=False)
+        trainer.train(nepoch=1, batch_size = 2, best_model=False, filename=None)
 
     def test_grid_graph_incompatible(self):
         dataset_train = GridDataset(
@@ -381,7 +381,7 @@ class TestTrainer(unittest.TestCase):
             )
 
             with warnings.catch_warnings(record=UserWarning):
-                trainer.train(nepoch=3, validate=True, best_model=False)
+                trainer.train(nepoch=3, validate=True, best_model=False, filename=self.save_path)
                 Trainer(
                     neuralnet = GINet,
                     dataset_train = dataset,
@@ -401,7 +401,7 @@ class TestTrainer(unittest.TestCase):
             )
 
             with warnings.catch_warnings(record=UserWarning):
-                trainer.train(nepoch=3, validate=True, best_model=False)
+                trainer.train(nepoch=3, validate=True, best_model=False, filename=self.save_path)
                 Trainer(
                     dataset_test = dataset,
                     pretrained_model=self.save_path
@@ -417,7 +417,7 @@ class TestTrainer(unittest.TestCase):
             neuralnet = GINet,
             dataset_train = dataset,
         )
-        trainer.train(batch_size = 1, best_model=False, save_model=False)
+        trainer.train(batch_size = 1, best_model=False, filename=None)
         assert len(trainer.train_loader) == int(0.75 * len(dataset))
         assert len(trainer.valid_loader) == int(0.25 * len(dataset))
 
@@ -432,7 +432,7 @@ class TestTrainer(unittest.TestCase):
             dataset_train = dataset,
             val_size = 0
         )
-        trainer.train(batch_size=1, best_model=False, save_model=False)
+        trainer.train(batch_size=1, best_model=False, filename=None)
         assert len(trainer.train_loader) == len(dataset)
         assert trainer.valid_loader is None
 
@@ -546,7 +546,7 @@ class TestTrainer(unittest.TestCase):
             )
 
             with warnings.catch_warnings(record=UserWarning):
-                trainer.train(nepoch=3, validate=True, best_model=False)
+                trainer.train(nepoch=3, validate=True, best_model=False, filename=self.save_path)
                 Trainer(
                     neuralnet = GINet,
                     dataset_train = dataset_train,

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -104,7 +104,7 @@ def _model_base_test( # pylint: disable=too-many-arguments, too-many-locals
                 assert data_tensor.is_cuda, f"data.{name} is not cuda"
 
     with warnings.catch_warnings(record=UserWarning):
-        trainer.train(nepoch=3, batch_size=64, validate=True, save_best_model=None)
+        trainer.train(nepoch=3, batch_size=64, validate=True, best_model=False, save_model=False)
         trainer.save_model(save_path)
 
         Trainer(
@@ -136,7 +136,7 @@ class TestTrainer(unittest.TestCase):
             CnnRegression,
             dataset
         )
-        trainer.train(nepoch=1, batch_size=2, save_best_model=None)
+        trainer.train(nepoch=1, batch_size=2, best_model=False, save_model=False)
 
     def test_grid_classification(self):
         dataset = GridDataset(
@@ -149,7 +149,7 @@ class TestTrainer(unittest.TestCase):
             CnnClassification,
             dataset
         )
-        trainer.train(nepoch=1, batch_size = 2, save_best_model=None)
+        trainer.train(nepoch=1, batch_size = 2, best_model=False, save_model=False)
 
     def test_grid_graph_incompatible(self):
         dataset_train = GridDataset(
@@ -382,7 +382,7 @@ class TestTrainer(unittest.TestCase):
             )
 
             with warnings.catch_warnings(record=UserWarning):
-                trainer.train(nepoch=3, validate=True, save_best_model=None)
+                trainer.train(nepoch=3, validate=True, best_model=False, save_model=False)
                 trainer.save_model(self.save_path)
                 Trainer(
                     neuralnet = GINet,
@@ -403,7 +403,7 @@ class TestTrainer(unittest.TestCase):
             )
 
             with warnings.catch_warnings(record=UserWarning):
-                trainer.train(nepoch=3, validate=True, save_best_model=None)
+                trainer.train(nepoch=3, validate=True, best_model=False, save_model=False)
                 trainer.save_model(self.save_path)
                 Trainer(
                     dataset_test = dataset,
@@ -420,7 +420,7 @@ class TestTrainer(unittest.TestCase):
             neuralnet = GINet,
             dataset_train = dataset,
         )
-        trainer.train(batch_size = 1, save_best_model=None)
+        trainer.train(batch_size = 1, best_model=False, save_model=False)
         assert len(trainer.train_loader) == int(0.75 * len(dataset))
         assert len(trainer.valid_loader) == int(0.25 * len(dataset))
 
@@ -435,7 +435,7 @@ class TestTrainer(unittest.TestCase):
             dataset_train = dataset,
             val_size = 0
         )
-        trainer.train(batch_size=1, save_best_model=None)
+        trainer.train(batch_size=1, best_model=False, save_model=False)
         assert len(trainer.train_loader) == len(dataset)
         assert trainer.valid_loader is None
 
@@ -459,7 +459,7 @@ class TestTrainer(unittest.TestCase):
         assert trainer.weight_decay == weight_decay
 
         with warnings.catch_warnings(record=UserWarning):
-            trainer.train(nepoch=3, save_best_model=None)
+            trainer.train(nepoch=3, best_model=False, save_model=False)
             trainer.save_model(self.save_path)
             trainer_pretrained = Trainer(
                 neuralnet = NaiveNetwork,
@@ -550,7 +550,7 @@ class TestTrainer(unittest.TestCase):
             )
 
             with warnings.catch_warnings(record=UserWarning):
-                trainer.train(nepoch=3, validate=True, save_best_model=None)
+                trainer.train(nepoch=3, validate=True, best_model=False, save_model=False)
                 trainer.save_model(self.save_path)
                 Trainer(
                     neuralnet = GINet,

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -104,7 +104,7 @@ def _model_base_test( # pylint: disable=too-many-arguments, too-many-locals
                 assert data_tensor.is_cuda, f"data.{name} is not cuda"
 
     with warnings.catch_warnings(record=UserWarning):
-        trainer.train(nepoch=3, batch_size=64, validate=True, best_model=False)
+        trainer.train(nepoch=3, batch_size=64, validate=True, best_model=False, filename=save_path)
 
         Trainer(
             model_class,
@@ -456,7 +456,7 @@ class TestTrainer(unittest.TestCase):
         assert trainer.weight_decay == weight_decay
 
         with warnings.catch_warnings(record=UserWarning):
-            trainer.train(nepoch=3, best_model=False)
+            trainer.train(nepoch=3, best_model=False, filename=self.save_path)
             trainer_pretrained = Trainer(
                 neuralnet = NaiveNetwork,
                 dataset_test=dataset,

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -104,8 +104,7 @@ def _model_base_test( # pylint: disable=too-many-arguments, too-many-locals
                 assert data_tensor.is_cuda, f"data.{name} is not cuda"
 
     with warnings.catch_warnings(record=UserWarning):
-        trainer.train(nepoch=3, batch_size=64, validate=True, best_model=False, save_model=False)
-        trainer.save_model(save_path)
+        trainer.train(nepoch=3, batch_size=64, validate=True, best_model=False)
 
         Trainer(
             model_class,
@@ -382,8 +381,7 @@ class TestTrainer(unittest.TestCase):
             )
 
             with warnings.catch_warnings(record=UserWarning):
-                trainer.train(nepoch=3, validate=True, best_model=False, save_model=False)
-                trainer.save_model(self.save_path)
+                trainer.train(nepoch=3, validate=True, best_model=False)
                 Trainer(
                     neuralnet = GINet,
                     dataset_train = dataset,
@@ -403,8 +401,7 @@ class TestTrainer(unittest.TestCase):
             )
 
             with warnings.catch_warnings(record=UserWarning):
-                trainer.train(nepoch=3, validate=True, best_model=False, save_model=False)
-                trainer.save_model(self.save_path)
+                trainer.train(nepoch=3, validate=True, best_model=False)
                 Trainer(
                     dataset_test = dataset,
                     pretrained_model=self.save_path
@@ -459,8 +456,7 @@ class TestTrainer(unittest.TestCase):
         assert trainer.weight_decay == weight_decay
 
         with warnings.catch_warnings(record=UserWarning):
-            trainer.train(nepoch=3, best_model=False, save_model=False)
-            trainer.save_model(self.save_path)
+            trainer.train(nepoch=3, best_model=False)
             trainer_pretrained = Trainer(
                 neuralnet = NaiveNetwork,
                 dataset_test=dataset,
@@ -550,8 +546,7 @@ class TestTrainer(unittest.TestCase):
             )
 
             with warnings.catch_warnings(record=UserWarning):
-                trainer.train(nepoch=3, validate=True, best_model=False, save_model=False)
-                trainer.save_model(self.save_path)
+                trainer.train(nepoch=3, validate=True, best_model=False)
                 Trainer(
                     neuralnet = GINet,
                     dataset_train = dataset_train,


### PR DESCRIPTION
Main changes proposed with this PR:
- `train` method has two distinct parameters now for indicating if the user wants to save either the best or the last model, and if the model needs to be saved. This way it's easier to do internal checks, and it's clearer for the user. 
- `save_model` method it's internal now and it saves only the state dict by default, into a variable which is then used in the code
  - The state dict needs to be retained to load the states of the best/last model at the end of the training loop
  - After the training loop is over, the best/last model state is saved in a file if the new flag `save_model` is True
- Before these edits, we were overriding the file every time we were saving the best model. Also, we were not loading the state dicts of the best model to the self.model and self.optimizer attributes. So we were then testing the model using the last updated model, which was always the last one. But in cases in which `best_model` was selected, again last was run on test set. Now it should be fixed.
- I modified the call to early stopping into the training loop in order to compare the current validation loss with the current training loss (and not the minimum training loss); indeed in each epoch we're interested in evaluating the current gap between the training and the validation loss. 
- I moved the early stopping call into the `if validate` statement, because if there is no validation there is no early stopping call. 
- We were saving test data into the exporter using epoch 0 as a placeholder; now the epoch saved is the one in which the model's state was saved, and that was actually run on the test, so the best/last one according to the user's choice. It's less confusing this way. 