### PR TITLE
fix: convert list of arrays into arrays before converting to Pytorch tensor

### DIFF
--- a/deeprankcore/dataset.py
+++ b/deeprankcore/dataset.py
@@ -540,12 +540,13 @@ class GridDataset(DeeprankDataset):
 
             mapped_features_group = entry_group[gridstorage.MAPPED_FEATURES]
             for feature_name in self.features:
-                feature_data.append(mapped_features_group[feature_name][:])
+                if feature_name[0] != '_':  # ignore metafeatures     
+                    feature_data.append(mapped_features_group[feature_name][:])
 
             target_value = entry_group[targets.VALUES][self.target][()]
 
         # Wrap up the data in this object, for the collate_fn to handle it properly:
-        data = Data(x=torch.tensor([feature_data], dtype=torch.float),
+        data = Data(x=torch.tensor(np.expand_dims(np.array(feature_data), axis=0), dtype=torch.float),
                     y=torch.tensor([target_value], dtype=torch.float))
 
         data.entry_names = entry_name


### PR DESCRIPTION
The following code in `GridDataset` (deeprankcore/dataset.py:549) `data = Data(x=torch.tensor([feature_data], dtype=torch.float)`, in which feature_data was a list of numpy arrays, gave this warning:

```bash
UserWarning: Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with numpy.array() before converting to a tensor. (Triggered internally at /opt/conda/conda-bld/pytorch_1670525539683/work/torch/csrc/utils/tensor_new.cpp:230.)
```

Now it is fixed by using numpy arrays instead of list object.

This PR solves the first part of #308 