### PR TITLE
CI: decrease sensitivity of `test_graph_augmented_write_as_grid_to_hdf5`

### DIFF
--- a/tests/utils/test_graph.py
+++ b/tests/utils/test_graph.py
@@ -235,7 +235,7 @@ def test_graph_augmented_write_as_grid_to_hdf5(graph):
                 assert (f5[f"{entry_id}/grid_points/center"][(
                 )] == f5[f"{aug_id}/grid_points/center"][()]).all()
                 assert np.abs(np.sum(data) -
-                              np.sum(unaugmented_data)).item() < 0.11
+                              np.sum(unaugmented_data)).item() < 0.2
 
                 # target
                 assert entry_group[Target.VALUES][target_name][(


### PR DESCRIPTION
This function doesn't always output the same result and rarely it had exceeded the 0.11 on my system and the test fails (but then passes if I rerun it). Can I increase it to 0.2 or could that be a problematic value?